### PR TITLE
More fixes for Julia master.

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -4,7 +4,7 @@ Rotations 0.6.0
 TypeSortedCollections 0.4.0
 LightXML 0.4.0
 DocStringExtensions 0.4.1
-Compat 0.27 # for Val constructor
+Compat 0.59 # for undef
 Reexport 0.0.3
 LoopThrottle 0.0.1
 Nullables # TODO: remove after dropping 0.6 support

--- a/perf/runbenchmarks.jl
+++ b/perf/runbenchmarks.jl
@@ -1,5 +1,6 @@
 using RigidBodyDynamics
 using Compat
+using Compat.Random
 using BenchmarkTools
 
 const ScalarType = Float64
@@ -24,7 +25,7 @@ function create_benchmark_suite()
     state = MechanismState{ScalarType}(mechanism)
     result = DynamicsResult{ScalarType}(mechanism)
     nv = num_velocities(state)
-    mat = MomentumMatrix(root_frame(mechanism), Matrix{ScalarType}(3, nv), Matrix{ScalarType}(3, nv))
+    mat = MomentumMatrix(root_frame(mechanism), Matrix{ScalarType}(undef, 3, nv), Matrix{ScalarType}(undef, 3, nv))
     torques = similar(velocity(state))
     rfoot = findbody(mechanism, "r_foot")
     lhand = findbody(mechanism, "l_hand")

--- a/src/joint_types.jl
+++ b/src/joint_types.jl
@@ -114,13 +114,13 @@ end
 end
 
 @inline translation(jt::QuaternionFloating, q::AbstractVector) = @inbounds return SVector(q[5], q[6], q[7])
-@inline translation!(q::AbstractVector, jt::QuaternionFloating, trans::AbstractVector) = @inbounds copy!(q, 5, trans, 1, 3)
+@inline translation!(q::AbstractVector, jt::QuaternionFloating, trans::AbstractVector) = @inbounds copyto!(q, 5, trans, 1, 3)
 
 @inline angular_velocity(jt::QuaternionFloating, v::AbstractVector) = @inbounds return SVector(v[1], v[2], v[3])
-@inline angular_velocity!(v::AbstractVector, jt::QuaternionFloating, ω::AbstractVector) = @inbounds copy!(v, 1, ω, 1, 3)
+@inline angular_velocity!(v::AbstractVector, jt::QuaternionFloating, ω::AbstractVector) = @inbounds copyto!(v, 1, ω, 1, 3)
 
 @inline linear_velocity(jt::QuaternionFloating, v::AbstractVector) = @inbounds return SVector(v[4], v[5], v[6])
-@inline linear_velocity!(v::AbstractVector, jt::QuaternionFloating, ν::AbstractVector) = @inbounds copy!(v, 4, ν, 1, 3)
+@inline linear_velocity!(v::AbstractVector, jt::QuaternionFloating, ν::AbstractVector) = @inbounds copyto!(v, 4, ν, 1, 3)
 
 function joint_transform(jt::QuaternionFloating, frame_after::CartesianFrame3D, frame_before::CartesianFrame3D, q::AbstractVector)
     Transform3D(frame_after, frame_before, rotation(jt, q), translation(jt, q))
@@ -234,11 +234,11 @@ function local_coordinates!(ϕ::AbstractVector, ϕ̇::AbstractVector,
     twist = joint_twist(jt, frame_after, frame0, q, v) # (q_0 is assumed not to change)
     ξ, ξ̇ = log_with_time_derivative(relative_transform, twist)
 
-    @inbounds copy!(ϕ, 1, angular(ξ), 1, 3)
-    @inbounds copy!(ϕ, 4, linear(ξ), 1, 3)
+    @inbounds copyto!(ϕ, 1, angular(ξ), 1, 3)
+    @inbounds copyto!(ϕ, 4, linear(ξ), 1, 3)
 
-    @inbounds copy!(ϕ̇, 1, angular(ξ̇), 1, 3)
-    @inbounds copy!(ϕ̇, 4, linear(ξ̇), 1, 3)
+    @inbounds copyto!(ϕ̇, 1, angular(ξ̇), 1, 3)
+    @inbounds copyto!(ϕ̇, 4, linear(ξ̇), 1, 3)
 
     nothing
 end

--- a/src/mechanism_state.jl
+++ b/src/mechanism_state.jl
@@ -422,7 +422,7 @@ $(SIGNATURES)
 Set the configuration vector ``q``. Invalidates cache variables.
 """
 function set_configuration!(state::MechanismState, q::AbstractVector)
-    copy!(parent(state.q), q)
+    copyto!(parent(state.q), q)
     setdirty!(state)
 end
 
@@ -432,7 +432,7 @@ $(SIGNATURES)
 Set the velocity vector ``v``. Invalidates cache variables.
 """
 function set_velocity!(state::MechanismState, v::AbstractVector)
-    copy!(state.v, v)
+    copyto!(state.v, v)
     setdirty!(state)
 end
 
@@ -442,22 +442,22 @@ $(SIGNATURES)
 Set the vector of additional states ``s``.
 """
 function set_additional_state!(state::MechanismState, s::AbstractVector)
-    copy!(state.s, s)
+    copyto!(state.s, s)
     # note: setdirty! is currently not needed because no cache variables depend on s
 end
 
-function Base.copy!(state::MechanismState, x::AbstractVector)
+function Compat.copyto!(state::MechanismState, x::AbstractVector)
     nq = num_positions(state)
     nv = num_velocities(state)
     ns = num_additional_states(state)
     @boundscheck length(x) == nq + nv + ns || throw(DimensionMismatch())
-    @inbounds copy!(parent(state.q), 1, x, 1, nq)
-    @inbounds copy!(parent(state.v), 1, x, nq + 1, nv)
-    @inbounds copy!(state.s, 1, x, nq + nv + 1, ns)
+    @inbounds copyto!(parent(state.q), 1, x, 1, nq)
+    @inbounds copyto!(parent(state.v), 1, x, nq + 1, nv)
+    @inbounds copyto!(state.s, 1, x, nq + nv + 1, ns)
     setdirty!(state)
 end
 
-Base.@deprecate set!(state::MechanismState, x::AbstractVector) copy!(state, x)
+Base.@deprecate set!(state::MechanismState, x::AbstractVector) copyto!(state, x)
 
 """
 $(SIGNATURES)
@@ -814,7 +814,7 @@ function configuration_derivative_to_velocity_adjoint!(
 end
 
 function configuration_derivative(state::MechanismState{X}) where {X}
-    ret = SegmentedVector(Vector{X}(num_positions(state.mechanism)), tree_joints(state.mechanism), num_positions)
+    ret = SegmentedVector(Vector{X}(undef, num_positions(state.mechanism)), tree_joints(state.mechanism), num_positions)
     configuration_derivative!(ret, state)
     ret
 end

--- a/src/ode_integrators.jl
+++ b/src/ode_integrators.jl
@@ -1,5 +1,7 @@
 module OdeIntegrators
 
+using Compat
+using Compat.LinearAlgebra
 using RigidBodyDynamics
 using StaticArrays
 using DocStringExtensions
@@ -80,7 +82,7 @@ mutable struct RingBufferStorage{T, Q<:AbstractVector, V<:AbstractVector} <: Ode
     function RingBufferStorage{T}(state, n) where {T}
         Q = typeof(configuration(state))
         V = typeof(velocity(state))
-        ts = Vector{T}(n)
+        ts = Vector{T}(undef, n)
         qs = [similar(configuration(state)) for i in 1 : n]
         vs = [similar(velocity(state)) for i in 1 : n]
         new{T, Q, V}(ts, qs, vs, 0)
@@ -96,8 +98,8 @@ end
 function process(storage::RingBufferStorage, t, state)
     index = storage.last_index % length(storage) + 1
     storage.ts[index] = t
-    copy!(storage.qs[index], configuration(state))
-    copy!(storage.vs[index], velocity(state))
+    copyto!(storage.qs[index], configuration(state))
+    copyto!(storage.vs[index], velocity(state))
     storage.last_index = index
     nothing
 end
@@ -130,10 +132,10 @@ initialize(storage::ExpandingStorage, t, state) = process(storage, t, state)
 function process(storage::ExpandingStorage, t, state)
     push!(storage.ts, t)
     q = similar(configuration(state))
-    copy!(q, configuration(state))
+    copyto!(q, configuration(state))
     push!(storage.qs, q)
     v = similar(velocity(state))
-    copy!(v, velocity(state))
+    copyto!(v, velocity(state))
     push!(storage.vs, v)
     nothing
 end

--- a/src/simulate.jl
+++ b/src/simulate.jl
@@ -38,8 +38,8 @@ function simulate(state0::MechanismState, final_time, control! = zero_torque!; �
     closed_loop_dynamics! = (v̇::AbstractArray, ṡ::AbstractArray, t, state) -> begin
         control!(control_torques, t, state)
         dynamics!(result, state, control_torques)
-        copy!(v̇, result.v̇)
-        copy!(ṡ, result.ṡ)
+        copyto!(v̇, result.v̇)
+        copyto!(ṡ, result.ṡ)
         nothing
     end
     tableau = runge_kutta_4(Float64)

--- a/src/spatial/motion_force_interaction.jl
+++ b/src/spatial/motion_force_interaction.jl
@@ -118,7 +118,7 @@ function Random.rand(::Type{<:SpatialInertia{T}}, frame::CartesianFrame3D) where
     principal_moments[3] = rand(T) * (ub - lb) + lb
 
     # Construct the moment of inertia tensor
-    J = SMatrix{3, 3, T}(Q * diagm(principal_moments) * Q')
+    J = SMatrix{3, 3, T}(Q * Diagonal(principal_moments) * Q')
 
     # Construct the inertia in CoM frame
     com_frame = CartesianFrame3D()

--- a/src/util.jl
+++ b/src/util.jl
@@ -147,7 +147,11 @@ macro indextype(ID)
         Base.start(r::StepRange{$ID}) = Int(r.start)
         Base.next(r::AbstractUnitRange{$ID}, i) = (convert($ID, i), i + 1)
         Base.done(r::AbstractUnitRange{$ID}, i) = i == oftype(i, r.stop) + 1
-        Base.colon(start::$ID, step::Int, stop::$ID) = StepRange(start, step, stop)
+        @static if VERSION < v"0.7-"
+            Base.colon(start::$ID, step::Int, stop::$ID) = StepRange(start, step, stop)
+        else
+            Base.:(:)(start::$ID, step::Int, stop::$ID) = StepRange(start, step, stop)
+        end
         Base.steprange_last(start::$ID, step::Int, stop::$ID) = $ID(Base.steprange_last(Int(start), step, Int(stop)))
     end)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,19 +27,17 @@ include("test_mechanism_modification.jl")
 include("test_pd_control.jl")
 
 # notebooks
-notebookdir = joinpath("..", "notebooks")
+notebookdir = joinpath(@__DIR__, "..", "notebooks")
 for file in readdir(notebookdir)
     name, ext = splitext(file)
-    if lowercase(ext) == ".ipynb"
-        @eval module $(gensym())
-            n = $name
-            using Compat.Test
-            using NBInclude
-            @testset "$n" begin
-                nbinclude(joinpath($notebookdir, $file), regex = r"^((?!\#NBSKIP).)*$"s)
-            end
-        end
+    lowercase(ext) == ".ipynb" || continue
+    @eval module $(gensym())
+    using Compat.Test
+    using NBInclude
+    @testset "$($name)" begin
+        nbinclude(joinpath($notebookdir, $file), regex = r"^((?!\#NBSKIP).)*$"s)
     end
+    end #module
 end
 
 # benchmarks

--- a/test/test_mechanism_modification.jl
+++ b/test/test_mechanism_modification.jl
@@ -102,8 +102,8 @@ end
         H21 = H[nq_single + 1 : end, 1 : nq_single]
         H22 = H[nq_single + 1 : end, nq_single + 1 : end]
         @test isapprox(H11, H22)
-        @test isapprox(H12, zeros(H12))
-        @test isapprox(H21, zeros(H21))
+        @test isapprox(H12, zero(H12))
+        @test isapprox(H21, zero(H21))
     end
 
     @testset "remove fixed joints" begin
@@ -242,8 +242,8 @@ end
             for (body1, body2) in bodymap
                 accel1 = relative_acceleration(result1, body1, world)
                 accel2 = relative_acceleration(result2, body2, bodymap[world])
-                @test isapprox(angular.((accel1, accel2))...)
-                @test isapprox(linear.((accel1, accel2))...)
+                @test isapprox(angular(accel1), angular(accel2))
+                @test isapprox(linear(accel1), linear(accel2))
             end
         end # for
     end # reattach

--- a/test/test_simulate.jl
+++ b/test/test_simulate.jl
@@ -18,8 +18,8 @@
         using RigidBodyDynamics.OdeIntegrators
         passive_dynamics! = (vd::AbstractArray, sd::AbstractArray, t, state) -> begin
             dynamics!(result, state)
-            copy!(vd, result.v̇)
-            copy!(sd, result.ṡ)
+            copyto!(vd, result.v̇)
+            copyto!(sd, result.ṡ)
             nothing
         end
         storage = RingBufferStorage{Float64}(x, 3)

--- a/test/test_spatial.jl
+++ b/test/test_spatial.jl
@@ -72,7 +72,7 @@ end
 
         # Test that the constructor works with dynamic arrays (which are
         # converted to static arrays internally)
-        I4 = @inferred(SpatialInertia(f2, eye(3), zeros(3), 1.0))
+        I4 = @inferred(SpatialInertia(f2, Matrix(1.0I, 3, 3), zeros(3), 1.0))
     end
 
     @testset "twist" begin


### PR DESCRIPTION
Passes tests (except for notebooks) on

```julia
julia> versioninfo()
Julia Version 0.7.0-DEV.4575
Commit b571283a4c (2018-03-14 20:10 UTC)
Platform Info:
  OS: macOS (x86_64-apple-darwin14.5.0)
  CPU: Intel(R) Core(TM) i7-3820QM CPU @ 2.70GHz
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-3.9.1 (ORCJIT, ivybridge)
Environment:
  JULIA_PKGDIR = /Users/twan/code/julia/RigidBodyDynamics
```

with https://github.com/JuliaArrays/StaticArrays.jl/pull/387 and https://github.com/FugroRoames/Rotations.jl/pull/54 and with rotation vector test commented out due to https://github.com/JuliaLang/julia/issues/26552. 