### PR TITLE
Make it easier to set joint configurations / velocities

### DIFF
--- a/notebooks/Four-bar linkage - simulation and visualization.ipynb
+++ b/notebooks/Four-bar linkage - simulation and visualization.ipynb
@@ -270,13 +270,13 @@
     }
    ],
    "source": [
-    "configuration(state, joint1)[:] = 1.6707963267948966 # θ\n",
-    "configuration(state, joint2)[:] = -1.4591054166649482 # γ\n",
-    "configuration(state, joint3)[:] = 1.5397303602625536 # ϕ\n",
+    "set_configuration!(state, joint1, 1.6707963267948966) # θ\n",
+    "set_configuration!(state, joint2, -1.4591054166649482) # γ\n",
+    "set_configuration!(state, joint3, 1.5397303602625536) # ϕ\n",
     "\n",
-    "velocity(state, joint1)[:] = 0.5\n",
-    "velocity(state, joint2)[:] = -0.47295\n",
-    "velocity(state, joint3)[:] = 0.341\n",
+    "set_velocity!(state, joint1, 0.5)\n",
+    "set_velocity!(state, joint2, -0.47295)\n",
+    "set_velocity!(state, joint3, 0.341)\n",
     "\n",
     "# Invalidate the cache variables\n",
     "setdirty!(state)"

--- a/notebooks/Quickstart - double pendulum.ipynb
+++ b/notebooks/Quickstart - double pendulum.ipynb
@@ -349,10 +349,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "configuration(state, shoulder)[:] = 0.3\n",
-    "configuration(state, elbow)[:] = 0.4\n",
-    "velocity(state, shoulder)[:] = 1.\n",
-    "velocity(state, elbow)[:] = 2.;"
+    "set_configuration!(state, shoulder, 0.3)\n",
+    "set_configuration!(state, elbow, 0.4)\n",
+    "set_velocity!(state, shoulder, 1.)\n",
+    "set_velocity!(state, elbow, 2.);"
    ]
   },
   {

--- a/notebooks/Simulation and visualization with a controller in the loop.ipynb
+++ b/notebooks/Simulation and visualization with a controller in the loop.ipynb
@@ -124,8 +124,8 @@
    "source": [
     "state = MechanismState(mechanism)\n",
     "zero_velocity!(state)\n",
-    "configuration(state, shoulder)[:] = 0.7\n",
-    "configuration(state, elbow)[:] = -0.8;"
+    "set_configuration!(state, shoulder, 0.7)\n",
+    "set_configuration!(state, elbow, -0.8);"
    ]
   },
   {

--- a/src/RigidBodyDynamics.jl
+++ b/src/RigidBodyDynamics.jl
@@ -178,8 +178,8 @@ using .Graphs
 import .Spatial: rotation, translation, transform, center_of_mass, newton_euler, kinetic_energy
 
 include("util.jl")
-include("joint_types.jl")
 include("joint.jl")
+include("joint_types.jl")
 include("rigid_body.jl")
 include("mechanism.jl")
 include("mechanism_modification.jl")

--- a/src/mechanism_state.jl
+++ b/src/mechanism_state.jl
@@ -398,8 +398,8 @@ $(SIGNATURES)
 Set the part of the configuration vector associated with `joint`.
 Invalidates cache variables.
 """
-function set_configuration!(state::MechanismState, joint::Joint, q::AbstractVector)
-    configuration(state, joint)[:] = q
+function set_configuration!(state::MechanismState, joint::Joint, config)
+    set_configuration!(configuration(state, joint), joint, config)
     reset_contact_state!(state)
     setdirty!(state)
 end
@@ -410,8 +410,8 @@ $(SIGNATURES)
 Set the part of the velocity vector associated with `joint`.
 Invalidates cache variables.
 """
-function set_velocity!(state::MechanismState, joint::Joint, v::AbstractVector)
-    velocity(state, joint)[:] = v
+function set_velocity!(state::MechanismState, joint::Joint, vel)
+    set_velocity!(velocity(state, joint), joint, vel)
     reset_contact_state!(state)
     setdirty!(state)
 end
@@ -422,7 +422,7 @@ $(SIGNATURES)
 Set the configuration vector ``q``. Invalidates cache variables.
 """
 function set_configuration!(state::MechanismState, q::AbstractVector)
-    copyto!(parent(state.q), q)
+    copyto!(state.q, q)
     setdirty!(state)
 end
 

--- a/test/test_simulate.jl
+++ b/test/test_simulate.jl
@@ -55,8 +55,9 @@
         state = MechanismState(mechanism)
         z0 = 0.05
         zero!(state)
-        RigidBodyDynamics.translation!(configuration(state, floatingjoint), joint_type(floatingjoint), SVector(1., 2., z0 - com.v[3]))
-        setdirty!(state)
+        tf = transform_to_root(state, body)
+        tf = Transform3D(frame_after(floatingjoint), frame_before(floatingjoint), rotation(tf), SVector(1., 2., z0 - com.v[3]))
+        set_configuration!(state, floatingjoint, tf)
 
         energy0 = gravitational_potential_energy(state)
         com_world = transform_to_root(state, body) * com


### PR DESCRIPTION
Fix #361.

* widen the signatures of `set_configuration!(state, joint, q)` and `set_velocity!(state, joint, v)` so that they accept `::Any` for their final arguments
* make `set_configuration!(state, joint, q)` and `set_velocity!(state, joint, v)` dispatch to joint-type-specific methods of the form `set_configuration!(q::AbstractVector, joint, config)` and `set_velocity!(v::AbstractVector, joint, config)`, which set the first argument based on the last, and allow dispatch on the type of the last argument and the joint type.
* using this new setup, add convenience methods for:
  * setting configuration/velocity given a `Number` for one-DoF joint types
  * setting configuration given a `Rotation{3}` for `QuaternionSpherical` joint types
  * setting configuration given a `Transform3D` for `QuaternionFloating` joint types
  * setting velocity given a `Twist` for `QuaternionFloating` joint types

(Also move `JointType` abstract type code to `joint.jl` and rename some internal methods).