### PR TITLE
WIP: implement jacobians for qdot <-> v

### DIFF
--- a/src/mechanism_state.jl
+++ b/src/mechanism_state.jl
@@ -863,6 +863,36 @@ function configuration_derivative(state::MechanismState{X}) where {X}
     ret
 end
 
+function velocity_to_configuration_derivative_jacobian!(Q_v::AbstractMatrix, state::MechanismState)
+    for joint in joints(state.mechanism)
+        qidx = configuration_range(state, joint)
+        vidx = velocity_range(state, joint)
+        velocity_to_configuration_derivative_jacobian!(@view(Q_v[qidx, vidx]), joint_type(joint), configuration(state, joint))
+    end
+    nothing
+end
+
+function velocity_to_configuration_derivative_jacobian(state::MechanismState{X, M, C}) where {X, M, C}
+    Q_v = spzeros(C, num_positions(state), num_velocities(state))
+    velocity_to_configuration_derivative_jacobian!(Q_v, state)
+    Q_v
+end
+
+function configuration_derivative_to_velocity_jacobian!(V_q::AbstractMatrix, state::MechanismState)
+    for joint in joints(state.mechanism)
+        qidx = configuration_range(state, joint)
+        vidx = velocity_range(state, joint)
+        configuration_derivative_to_velocity_jacobian!(@view(V_q[vidx, qidx]), joint_type(joint), configuration(state, joint))
+    end
+    nothing
+end
+
+function configuration_derivative_to_velocity_jacobian(state::MechanismState{X, M, C}) where {X, M, C}
+    V_q = spzeros(C, num_velocities(state), num_positions(state))
+    configuration_derivative_to_velocity_jacobian!(V_q, state)
+    V_q
+end
+
 function transform_to_root(state::MechanismState, frame::CartesianFrame3D)
     body = body_fixed_frame_to_body(state.mechanism, frame) # FIXME: expensive
     tf = transform_to_root(state, body)

--- a/test/test_mechanism_algorithms.jl
+++ b/test/test_mechanism_algorithms.jl
@@ -110,6 +110,20 @@ end
             configuration_derivative_to_velocity!(vjoint_from_q̇, joint, qjoint, q̇joint)
             @test isapprox(vjoint, vjoint_from_q̇; atol = 1e-12)
         end
+
+        V_q = RigidBodyDynamics.configuration_derivative_to_velocity_jacobian(x)
+        Q_v = RigidBodyDynamics.velocity_to_configuration_derivative_jacobian(x)
+        RigidBodyDynamics.configuration_derivative_to_velocity_jacobian!(V_q, x)
+        RigidBodyDynamics.velocity_to_configuration_derivative_jacobian!(Q_v, x)
+        for i in 1:100
+            rand!(x)
+            allocs = @allocated RigidBodyDynamics.configuration_derivative_to_velocity_jacobian!(V_q, x)
+            @test_broken allocs == 0
+            allocs = @allocated RigidBodyDynamics.velocity_to_configuration_derivative_jacobian!(Q_v, x)
+            @test_broken allocs == 0
+            @test velocity(x) ≈ V_q * configuration_derivative(x)
+            @test configuration_derivative(x) ≈ Q_v * velocity(x)
+        end
     end
 
     @testset "set_configuration! / set_velocity!" begin


### PR DESCRIPTION
I haven't done any work to make this perform well yet, but I wanted to at least get the functions written and tested before I start optimizing. This uses the plain sparse matrix approach we discussed, and I'm pretty confident that I can get it down to zero allocations for the in-place version. We should be able to swap out the sparse matrix for a custom matrix type at a later date without breaking things. 