### PR TITLE
Fix random seeds for tests.

### DIFF
--- a/perf/runbenchmarks.jl
+++ b/perf/runbenchmarks.jl
@@ -129,6 +129,7 @@ function runbenchmarks()
     suite = create_benchmark_suite()
     Profile.clear_malloc_data()
     overhead = BenchmarkTools.estimate_overhead()
+    Random.seed!(1)
     results = run(suite, verbose=true, overhead=overhead, gctrial=false)
     for result in results
         println("$(first(result)):")

--- a/test/test_caches.jl
+++ b/test/test_caches.jl
@@ -2,6 +2,7 @@ module TestCaches
 
 using Test
 using RigidBodyDynamics
+import Random
 
 function randmech()
     rand_tree_mechanism(Float64, [QuaternionFloating{Float64}; [Revolute{Float64} for i = 1 : 5]; [Fixed{Float64} for i = 1 : 5]; [QuaternionSpherical{Float64} for i = 1 : 5]; [Prismatic{Float64} for i = 1 : 5]; [Planar{Float64} for i = 1 : 5]]...)
@@ -23,18 +24,21 @@ function cachetest(cache, eltypefun)
 end
 
 @testset "StateCache" begin
+    Random.seed!(1)
     mechanism = randmech()
     cache = StateCache(mechanism)
     cachetest(cache, RigidBodyDynamics.state_vector_eltype)
 end
 
 @testset "DynamicsResultCache" begin
+    Random.seed!(2)
     mechanism = randmech()
     cache = DynamicsResultCache(mechanism)
     cachetest(cache, result -> eltype(result.v̇))
 end
 
 @testset "SegmentedVectorCache" begin
+    Random.seed!(3)
     mechanism = randmech()
     state = MechanismState(mechanism)
     cache = SegmentedVectorCache(RigidBodyDynamics.ranges(velocity(state)))

--- a/test/test_contact.jl
+++ b/test/test_contact.jl
@@ -1,5 +1,6 @@
 @testset "contact" begin
     @testset "HalfSpace3D" begin
+        Random.seed!(1)
         frame = CartesianFrame3D()
         point = Point3D(frame, rand(), rand(), rand())
         normal = FreeVector3D(frame, 0., 0., 1.)

--- a/test/test_custom_collections.jl
+++ b/test/test_custom_collections.jl
@@ -1,5 +1,6 @@
 using Test
 using RigidBodyDynamics
+import Random
 
 # A pathologically weird matrix which uses base -1 indexing
 # for its first dimension and base 2 indexing for its second
@@ -62,6 +63,7 @@ Base.axes(m::NonOneBasedMatrix) = ((1:m.m) .- 2, (1:m.n) .+ 1)
     end
 
     @testset "SegmentedBlockDiagonalMatrix" begin
+        Random.seed!(1)
         A = rand(10, 10)
         block_indices = [(1:1, 1:1),  # square
                          (2:4, 2:2),  # non-square

--- a/test/test_double_pendulum.jl
+++ b/test/test_double_pendulum.jl
@@ -1,4 +1,5 @@
 @testset "double pendulum" begin
+    Random.seed!(1)
     lc1 = -0.5
     l1 = -1.
     m1 = 1.

--- a/test/test_frames.jl
+++ b/test/test_frames.jl
@@ -1,4 +1,5 @@
 @testset "frames" begin
+    Random.seed!(1)
     f1name = "1"
     f1 = CartesianFrame3D(f1name)
     f2 = CartesianFrame3D()

--- a/test/test_graph.jl
+++ b/test/test_graph.jl
@@ -2,6 +2,7 @@ Graphs.flip_direction(edge::Edge{Int32}) = Edge(-edge.data)
 
 @testset "graphs" begin
     @testset "disconnected" begin
+        Random.seed!(1)
         graph = DirectedGraph{Vertex{Int64}, Edge{Float64}}()
         verts = [Vertex(rand(Int64)) for i = 1 : 10]
         for v in verts
@@ -22,6 +23,7 @@ Graphs.flip_direction(edge::Edge{Int32}) = Edge(-edge.data)
 
 
     @testset "tree graph" begin
+        Random.seed!(1)
         graph = DirectedGraph{Vertex{Int64}, Edge{Float64}}()
         root = Vertex(rand(Int64))
         add_vertex!(graph, root)
@@ -49,6 +51,7 @@ Graphs.flip_direction(edge::Edge{Int32}) = Edge(-edge.data)
     end
 
     @testset "remove_vertex!" begin
+        Random.seed!(1)
         graph = DirectedGraph{Vertex{Int64}, Edge{Float64}}()
         edge = Edge(rand())
         add_edge!(graph, Vertex(rand(Int64)), Vertex(rand(Int64)), edge)
@@ -80,6 +83,7 @@ Graphs.flip_direction(edge::Edge{Int32}) = Edge(-edge.data)
     end
 
     @testset "remove_edge!" begin
+        Random.seed!(1)
         graph = DirectedGraph{Vertex{Int64}, Edge{Float64}}()
         for i = 1 : 100
             add_vertex!(graph, Vertex(i))
@@ -106,6 +110,7 @@ Graphs.flip_direction(edge::Edge{Int32}) = Edge(-edge.data)
     end
 
     @testset "rewire!" begin
+        Random.seed!(1)
         graph = DirectedGraph{Vertex{Int64}, Edge{Float64}}()
         for i = 1 : 100
             add_vertex!(graph, Vertex(i))
@@ -140,6 +145,7 @@ Graphs.flip_direction(edge::Edge{Int32}) = Edge(-edge.data)
     end
 
     @testset "replace_edge!" begin
+        Random.seed!(1)
         graph = DirectedGraph{Vertex{Int64}, Edge{Float64}}()
         for i = 1 : 100
             add_vertex!(graph, Vertex(i))
@@ -169,6 +175,7 @@ Graphs.flip_direction(edge::Edge{Int32}) = Edge(-edge.data)
     end
 
     @testset "SpanningTree" begin
+        Random.seed!(1)
         rootdata = 0
 
         # graph1: tree grown incrementally
@@ -320,6 +327,7 @@ Graphs.flip_direction(edge::Edge{Int32}) = Edge(-edge.data)
     end
 
     @testset "reindex!" begin
+        Random.seed!(1)
         graph = DirectedGraph{Vertex{Int64}, Edge{Float64}}()
         for i = 1 : 100
             add_vertex!(graph, Vertex(i))
@@ -337,6 +345,7 @@ Graphs.flip_direction(edge::Edge{Int32}) = Edge(-edge.data)
     end
 
     @testset "map-like constructor" begin
+        Random.seed!(1)
         graph = DirectedGraph{Vertex{Int32}, Edge{Float32}}()
         for i = Int32(1) : Int32(100)
             add_vertex!(graph, Vertex(i))

--- a/test/test_mechanism_algorithms.jl
+++ b/test/test_mechanism_algorithms.jl
@@ -4,6 +4,7 @@ end
 
 @testset "mechanism algorithms" begin
     @testset "show" begin
+        Random.seed!(17)
         mechanism = randmech()
         x = MechanismState(mechanism)
         rand!(x)
@@ -28,6 +29,7 @@ end
     end
 
     @testset "basic stuff" begin
+        Random.seed!(18)
         mechanism = randmech()
         for joint in joints(mechanism)
             @test eltype(joint_type(joint)) == Float64
@@ -84,6 +86,7 @@ end
     end
 
     @testset "copyto! / Vector" begin
+        Random.seed!(19)
         mechanism = randmech()
         x1 = MechanismState(mechanism)
         rand!(x1)
@@ -100,6 +103,7 @@ end
     end
 
     @testset "q̇ <-> v" begin
+        Random.seed!(20)
         mechanism = randmech()
         x = MechanismState(mechanism)
         rand!(x)
@@ -147,6 +151,7 @@ end
     end
 
     @testset "set_configuration! / set_velocity!" begin
+        Random.seed!(21)
         mechanism = randmech()
         x = MechanismState(mechanism)
         for joint in joints(mechanism)
@@ -192,6 +197,7 @@ end
     end
 
     @testset "normalize_configuration!" begin
+        Random.seed!(22)
         mechanism = randmech()
         let x = MechanismState(mechanism) # required to achieve zero allocations
             configuration(x) .= 1
@@ -210,6 +216,7 @@ end
     end
 
     @testset "joint_torque! / motion_subspace" begin
+        Random.seed!(23)
         mechanism = randmech()
         x = MechanismState(mechanism)
         rand!(x)
@@ -225,6 +232,7 @@ end
     end
 
     @testset "isfloating" begin
+        Random.seed!(24)
         mechanism = randmech()
         x = MechanismState(mechanism)
         rand!(x)
@@ -237,6 +245,7 @@ end
     end
 
     @testset "geometric_jacobian / relative_twist" begin
+        Random.seed!(25)
         mechanism = randmech()
         x = MechanismState(mechanism)
         rand!(x)
@@ -272,6 +281,7 @@ end
     end
 
     @testset "point jacobian" begin
+        Random.seed!(26)
         mechanism = randmech()
         x = MechanismState(mechanism)
         rand!(x)
@@ -312,6 +322,7 @@ end
         end
 
         @testset "point expressed in world frame" begin
+            Random.seed!(27)
             for i = 1 : 10
                 bs = Set(bodies(mechanism))
                 body = rand([bs...])
@@ -336,6 +347,7 @@ end
     end
 
     @testset "motion_subspace / constraint_wrench_subspace" begin
+        Random.seed!(28)
         mechanism = randmech()
         x = MechanismState(mechanism)
         rand!(x)
@@ -369,6 +381,7 @@ end
     # end
 
     @testset "relative_acceleration" begin
+        Random.seed!(29)
         mechanism = randmech()
         x = MechanismState(mechanism)
         rand!(x)
@@ -401,6 +414,7 @@ end
     end
 
     @testset "motion subspace / twist wrt world" begin
+        Random.seed!(30)
         mechanism = randmech()
         x = MechanismState(mechanism)
         rand!(x)
@@ -414,6 +428,7 @@ end
     end
 
     @testset "composite rigid body inertias" begin
+        Random.seed!(31)
         mechanism = randmech()
         x = MechanismState(mechanism)
         rand!(x)
@@ -434,6 +449,7 @@ end
     end
 
     @testset "momentum_matrix / summing momenta" begin
+        Random.seed!(32)
         mechanism = randmech()
         x = MechanismState(mechanism)
         rand!(x)
@@ -470,6 +486,7 @@ end
     end
 
     @testset "mass matrix / kinetic energy" begin
+        Random.seed!(33)
         mechanism = randmech()
         x = MechanismState(mechanism)
         rand!(x)
@@ -496,6 +513,7 @@ end
     end
 
     @testset "spatial_inertia!" begin
+        Random.seed!(34)
         mechanism = randmech()
         body = rand(collect(non_root_bodies(mechanism)))
         newinertia = rand(SpatialInertia{eltype(mechanism)}, spatial_inertia(body).frame)
@@ -504,6 +522,7 @@ end
     end
 
     @testset "inverse dynamics / acceleration term" begin
+        Random.seed!(35)
         mechanism = randmech()
         x = MechanismState(mechanism)
         rand!(x)
@@ -519,6 +538,7 @@ end
     end
 
     @testset "inverse dynamics / Coriolis term" begin
+        Random.seed!(36)
         mechanism = rand_tree_mechanism(Float64, [[Revolute{Float64} for i = 1 : 10]; [Prismatic{Float64} for i = 1 : 10]]...) # skew symmetry property tested later on doesn't hold when q̇ ≠ v
         x = MechanismState{Float64}(mechanism)
         rand!(x)
@@ -556,6 +576,7 @@ end
     end
 
     @testset "inverse dynamics / gravity term" begin
+        Random.seed!(37)
         mechanism = rand_tree_mechanism(Float64, [[Revolute{Float64} for i = 1 : 10]; [Prismatic{Float64} for i = 1 : 10]]...)
         x = MechanismState(mechanism)
         rand!(x)
@@ -578,6 +599,7 @@ end
     end
 
     @testset "momentum matrix" begin
+        Random.seed!(38)
         mechanism = randmech()
         x = MechanismState(mechanism)
         rand!(x)
@@ -607,6 +629,7 @@ end
     end
 
     @testset "inverse dynamics / external wrenches" begin
+        Random.seed!(39)
         mechanism = rand_chain_mechanism(Float64, [QuaternionFloating{Float64}; [Revolute{Float64} for i = 1 : 10]; Planar{Float64}; [Prismatic{Float64} for i = 1 : 10]]...) # what really matters is that there's a floating joint first
         x = MechanismState(mechanism)
         rand!(x)
@@ -627,6 +650,7 @@ end
     end
 
     @testset "dynamics / inverse dynamics" begin
+        Random.seed!(40)
         mechanism = randmech()
         x = MechanismState(mechanism)
         rand!(x)
@@ -639,6 +663,7 @@ end
     end
 
     @testset "dynamics_bias / inverse_dynamics" begin
+        Random.seed!(41)
         mechanism = randmech()
         x = MechanismState(mechanism)
         rand!(x)
@@ -651,6 +676,7 @@ end
     end
 
     @testset "dynamics ode method" begin
+        Random.seed!(42)
         mechanism = randmech()
         x = MechanismState(mechanism)
         rand!(x)
@@ -668,6 +694,7 @@ end
     end
 
     @testset "power flow" begin
+        Random.seed!(43)
         mechanism = randmech()
         x = MechanismState(mechanism)
         rand!(x)
@@ -694,6 +721,7 @@ end
     end
 
     @testset "local / global coordinates" begin
+        Random.seed!(44)
         mechanism = randmech()
         state = MechanismState(mechanism)
         rand!(state)
@@ -733,6 +761,7 @@ end
     end
 
     @testset "configuration_derivative_to_velocity_adjoint!" begin
+        Random.seed!(45)
         mechanism = randmech()
         x = MechanismState(mechanism)
         configuration(x) .= rand(num_positions(x)) # needs to work for configuration vectors that do not satisfy the state constraints as well
@@ -759,6 +788,7 @@ end
     end
 
     @testset "issue #330" begin
+        Random.seed!(46)
         mechanism = rand_tree_mechanism(Revolute{Float64})
         f330(x::AbstractArray{T}) where {T} = begin
             result = DynamicsResult{T}(mechanism)

--- a/test/test_mechanism_modification.jl
+++ b/test/test_mechanism_modification.jl
@@ -19,6 +19,7 @@
     end
 
     @testset "attach!" begin
+        Random.seed!(47)
         body0 = RigidBody{Float64}("root")
         mechanism = Mechanism(body0)
         joint1 = Joint("joint1", rand(Revolute{Float64}))
@@ -52,6 +53,7 @@
     end
 
     @testset "attach! mechanism" begin
+        Random.seed!(48)
         mechanism = rand_tree_mechanism(Float64, [QuaternionFloating{Float64}; [Revolute{Float64} for i = 1 : 10]; QuaternionSpherical{Float64}; Planar{Float64}; [Prismatic{Float64} for i = 1 : 10]]...)
         nq = num_positions(mechanism)
         nv = num_velocities(mechanism)
@@ -110,6 +112,7 @@
     end
 
     @testset "remove fixed joints" begin
+        Random.seed!(49)
         joint_types = [QuaternionFloating{Float64}; [Revolute{Float64} for i = 1 : 10]; QuaternionSpherical{Float64}; Planar{Float64}; [Fixed{Float64} for i = 1 : 10]]
         shuffle!(joint_types)
         mechanism = rand_tree_mechanism(Float64, joint_types...)
@@ -128,6 +131,7 @@
     end
 
     @testset "replace joint" begin
+        Random.seed!(50)
         jointtypes = [QuaternionFloating{Float64}; QuaternionSpherical{Float64}; Planar{Float64}; [Revolute{Float64} for i = 1 : 10]]
         shuffle!(jointtypes)
         mechanism = rand_tree_mechanism(Float64, jointtypes...)
@@ -144,6 +148,7 @@
     end
 
     @testset "submechanism" begin
+        Random.seed!(51)
         for testnum = 1 : 100
             # joint_types = [QuaternionFloating{Float64}; [Revolute{Float64} for i = 1 : 10]; QuaternionSpherical{Float64}; Planar{Float64}; [Fixed{Float64} for i = 1 : 10]] # FIXME: use this
             joint_types = [Revolute{Float64} for i = 1 : 4]
@@ -172,6 +177,7 @@
     end
 
     @testset "reattach" begin
+        Random.seed!(52)
         for testnum = 1 : 10
             # create random floating mechanism
             joint_types = [[Prismatic{Float64} for i = 1 : 10]; [Revolute{Float64} for i = 1 : 10]; [Fixed{Float64} for i = 1 : 10]]
@@ -252,6 +258,7 @@
     end # reattach
 
     @testset "maximal coordinates" begin
+        Random.seed!(53)
         # create random tree mechanism and equivalent mechanism in maximal coordinates
         tree_mechanism = rand_tree_mechanism(Float64, [QuaternionFloating{Float64}; QuaternionSpherical{Float64}; Planar{Float64}; [Revolute{Float64} for i = 1 : 10]; [Fixed{Float64} for i = 1 : 5]; [Prismatic{Float64} for i = 1 : 10]]...);
         mc_mechanism, newfloatingjoints, bodymap, jointmap = maximal_coordinates(tree_mechanism)
@@ -292,6 +299,7 @@
     end # maximal coordinates
 
     @testset "generic scalar dynamics" begin # TODO: move to a better place
+        Random.seed!(54)
         mechanism = rand_tree_mechanism(Float64, [QuaternionFloating{Float64}; [Revolute{Float64} for i = 1 : 10]; QuaternionSpherical{Float64}; Planar{Float64}; [Fixed{Float64} for i = 1 : 5]; [Prismatic{Float64} for i = 1 : 10]]...);
         mechanism, newfloatingjoints, bodymap, jointmap = maximal_coordinates(mechanism)
 
@@ -313,6 +321,7 @@
     end
 
     @testset "modcount" begin
+        Random.seed!(55)
         mechanism = rand_tree_mechanism(Float64, [QuaternionFloating{Float64}; [Revolute{Float64} for i = 1 : 10]; QuaternionSpherical{Float64}; Planar{Float64}; [Fixed{Float64} for i = 1 : 5]; [Prismatic{Float64} for i = 1 : 10]]...);
         state = MechanismState(mechanism)
         attach!(mechanism, root_body(mechanism), RigidBody(rand(SpatialInertia{Float64}, CartesianFrame3D())), Joint("bla", QuaternionFloating{Float64}()))

--- a/test/test_pd_control.jl
+++ b/test/test_pd_control.jl
@@ -18,6 +18,7 @@
     end
 
     @testset "x-axis rotation" begin
+        Random.seed!(56)
         gains = PDGains(2, 3)
         e = RotX(rand())
         ė = rand() * SVector(1, 0, 0)
@@ -25,6 +26,7 @@
     end
 
     @testset "orientation control" begin
+        Random.seed!(57)
         mechanism = rand_floating_tree_mechanism(Float64) # single floating body
         joint = first(tree_joints(mechanism))
         body = successor(joint, mechanism)
@@ -65,6 +67,7 @@
     end
 
     @testset "pose control" begin
+        Random.seed!(58)
         mechanism = rand_floating_tree_mechanism(Float64) # single floating body
         joint = first(tree_joints(mechanism))
         body = successor(joint, mechanism)
@@ -104,6 +107,7 @@
     end
 
     @testset "linearized SE(3) control" begin
+        Random.seed!(59)
         for i = 1 : 100
             randpsd3() = (x = rand(SMatrix{3, 3}); x' * x)
             baseframe = CartesianFrame3D("base")

--- a/test/test_simulate.jl
+++ b/test/test_simulate.jl
@@ -1,5 +1,6 @@
 @testset "simulation" begin
     @testset "simulate" begin
+        Random.seed!(60)
         # use simulate function (Munthe-Kaas integrator)
         acrobot = parse_urdf(Float64, joinpath(@__DIR__, "urdf", "Acrobot.urdf"))
         x = MechanismState(acrobot)
@@ -34,7 +35,7 @@
         # Drop a single rigid body with a contact point at the center of mass
         # onto the floor with a conservative contact model. Check energy
         # balances and bounce heights.
-
+        Random.seed!(61)
         world = RigidBody{Float64}("world")
         mechanism = Mechanism(world)
         bodyframe = CartesianFrame3D()

--- a/test/test_spatial.jl
+++ b/test/test_spatial.jl
@@ -11,6 +11,7 @@ end
     f4 = CartesianFrame3D("4")
 
     @testset "rotation vector rate" begin
+        Random.seed!(62)
         hat = RigidBodyDynamics.Spatial.hat
         rotation_vector_rate = RigidBodyDynamics.Spatial.rotation_vector_rate
         for ϕ in (rand(SVector{3}), zero(SVector{3})) # exponential coordinates (rotation vector)
@@ -46,6 +47,7 @@ end
     end
 
     @testset "show" begin
+        Random.seed!(63)
         show(devnull, rand(SpatialInertia{Float64}, f1))
         show(devnull, rand(Twist{Float64}, f2, f1, f3))
         show(devnull, rand(SpatialAcceleration{Float64}, f2, f1, f3))
@@ -59,6 +61,7 @@ end
     end
 
     @testset "spatial inertia" begin
+        Random.seed!(64)
         I2 = rand(SpatialInertia{Float64}, f2)
         H21 = rand(Transform3D, f2, f1)
         I1 = transform(I2, H21)
@@ -76,6 +79,7 @@ end
     end
 
     @testset "twist" begin
+        Random.seed!(65)
         T1 = rand(Twist{Float64}, f2, f1, f3)
         T2 = rand(Twist{Float64}, f3, f2, f3)
         T3 = T1 + T2
@@ -103,6 +107,7 @@ end
     end
 
     @testset "wrench" begin
+        Random.seed!(66)
         W = rand(Wrench{Float64}, f2)
         H21 = rand(Transform3D, f2, f1)
         @test isapprox(Array(transform(W, H21)), Ad(inv(H21))' * Array(W))
@@ -133,6 +138,7 @@ end
     end
 
     @testset "momentum" begin
+        Random.seed!(67)
         T = rand(Twist{Float64}, f2, f1, f2)
         I = rand(SpatialInertia{Float64}, f2)
         T2 = rand(Twist{Float64}, f2, f1, f1)
@@ -147,6 +153,7 @@ end
     end
 
     @testset "geometric jacobian, power" begin
+        Random.seed!(68)
         n = 14
         J = GeometricJacobian(f2, f1, f3, rand(SMatrix{3, n}), rand(SMatrix{3, n}))
         v = rand(size(J, 2))
@@ -167,6 +174,7 @@ end
     end
 
     @testset "mul! with transpose(mat)" begin
+        Random.seed!(69)
         mat = WrenchMatrix(f1, rand(SMatrix{3, 4}), rand(SMatrix{3, 4}))
         vec = rand(SpatialAcceleration{Float64}, f2, f3, f1)
         k = fill(NaN, size(mat, 2))
@@ -175,6 +183,7 @@ end
     end
 
     @testset "momentum matrix" begin
+        Random.seed!(70)
         n = 13
         A = MomentumMatrix(f3, rand(SMatrix{3, n}), rand(SMatrix{3, n}))
         v = rand(size(A, 2))
@@ -185,6 +194,7 @@ end
     end
 
     @testset "spatial acceleration" begin
+        Random.seed!(71)
         I = rand(SpatialInertia{Float64}, f2)
         Ṫ = rand(SpatialAcceleration{Float64}, f2, f1, f2)
         T = rand(Twist{Float64}, f2, f1, f2)
@@ -212,6 +222,7 @@ end
     end
 
     @testset "kinetic energy" begin
+        Random.seed!(72)
         I = rand(SpatialInertia{Float64}, f2)
         T = rand(Twist{Float64}, f2, f1, f2)
         H = rand(Transform3D, f2, f1)
@@ -221,8 +232,8 @@ end
     end
 
     @testset "log / exp" begin
+        Random.seed!(74) # TODO: https://github.com/JuliaRobotics/RigidBodyDynamics.jl/issues/135
         hat = RigidBodyDynamics.Spatial.hat
-        Random.seed!(1) # TODO: https://github.com/JuliaRobotics/RigidBodyDynamics.jl/issues/135
         for θ in [LinRange(0., 10 * eps(), 100);
                   LinRange(0., π - eps(), 100)]
             # have magnitude of parts of twist be bounded by θ to check for numerical issues
@@ -277,6 +288,7 @@ end
     end
 
     @testset "RodriguesVec linearization" begin
+        Random.seed!(75)
         ϵ = 1e-3
         for i = 1 : 100
             e = RotMatrix(AngleAxis(ϵ, randn(), randn(), randn()))


### PR DESCRIPTION
Should have done this a long time ago. Makes it easier to debug test failures on CI like the one in https://github.com/JuliaRobotics/RigidBodyDynamics.jl/pull/475 and makes it so that adding a test case doesn't affect other test cases that are run later. Should really not be using the global RNG anyway, but that requires a fix for https://github.com/JuliaRobotics/RigidBodyDynamics.jl/issues/459. Use different seeds between test sets to avoid testing the same mechanism in all tests.