### PR TITLE
fix DynamicsCache lookup for mechanisms with contact points

### DIFF
--- a/src/dynamics_result.jl
+++ b/src/dynamics_result.jl
@@ -61,7 +61,7 @@ mutable struct DynamicsResult{T, M}
             b => Vector{Vector{DefaultSoftContactStateDeriv{T}}}() for b in bodies(mechanism))
         startind = Ref(1)
         for body in bodies(mechanism)
-            for point::DefaultContactPoint{T} in contact_points(body)
+            for point::DefaultContactPoint{M} in contact_points(body)
                 model = contact_model(point)
                 n = num_states(model)
                 push!(contact_state_derivs[body], collect(begin

--- a/test/test_caches.jl
+++ b/test/test_caches.jl
@@ -2,6 +2,7 @@ module TestCaches
 
 using Test
 using RigidBodyDynamics
+using RigidBodyDynamics.Contact
 import Random
 
 function randmech()
@@ -31,10 +32,24 @@ end
 end
 
 @testset "DynamicsResultCache" begin
-    Random.seed!(2)
-    mechanism = randmech()
-    cache = DynamicsResultCache(mechanism)
-    cachetest(cache, result -> eltype(result.v̇))
+    @testset "Basic mechanism" begin
+        Random.seed!(2)
+        mechanism = randmech()
+        cache = DynamicsResultCache(mechanism)
+        cachetest(cache, result -> eltype(result.v̇))
+    end
+
+    @testset "Mechanism with contact points (Issue #483)" begin
+        Random.seed!(3)
+        mechanism = randmech()
+        contactmodel = SoftContactModel(hunt_crossley_hertz(k = 500e3), 
+            ViscoelasticCoulombModel(0.8, 20e3, 100.))
+        body = rand(bodies(mechanism))
+        add_contact_point!(body, 
+            ContactPoint(Point3D(default_frame(body), 0.0, 0.0, 0.0), contactmodel))
+        cache = DynamicsResultCache(mechanism)
+        cachetest(cache, result -> eltype(result.v̇))
+    end
 end
 
 @testset "SegmentedVectorCache" begin


### PR DESCRIPTION
Fixes #483 

I can also just remove the annotation, but on the assumption that it was put there for a reason, I figured I would just fix it. 