### PR TITLE
Implement principal_value! for quaternion-parameterized joints.

### DIFF
--- a/src/joint_types.jl
+++ b/src/joint_types.jl
@@ -249,6 +249,11 @@ function is_configuration_normalized(jt::QuaternionFloating, q::AbstractVector, 
     isapprox(quatnorm(rotation(jt, q, false)), one(eltype(q)); rtol = rtol, atol = atol)
 end
 
+function principal_value!(q::AbstractVector, jt::QuaternionFloating)
+    quat = rotation(jt, q)
+    set_rotation!(q, jt, principal_value(quat))
+    nothing
+end
 
 #=
 OneDegreeOfFreedomFixedAxis
@@ -813,6 +818,11 @@ function is_configuration_normalized(jt::QuaternionSpherical, q::AbstractVector,
     isapprox(quatnorm(rotation(jt, q, false)), one(eltype(q)); rtol = rtol, atol = atol)
 end
 
+function principal_value!(q::AbstractVector, jt::QuaternionSpherical)
+    quat = rotation(jt, q)
+    set_rotation!(q, jt, principal_value(quat))
+    nothing
+end
 
 """
 $(TYPEDEF)
@@ -1009,4 +1019,5 @@ end
 function principal_value!(q::AbstractVector, jt::SPQuatFloating)
     spq = rotation(jt, q)
     set_rotation!(q, jt, principal_value(spq))
+    nothing
 end


### PR DESCRIPTION
Also use `principal_value!` to fix the local / global coordinates test.

cc: @ryanelandt. Re: https://github.com/JuliaRobotics/RigidBodyDynamics.jl/pull/484#issuecomment-421230666, I think the fixed test case is a good example of why it would be useful to have this for quaternion-parameterized joints as well. It's also just a matter of consistency. Regarding performance: `principal_value!` would only be useful for certain applications; it won't be called in e.g. the `dynamics!` algorithm. And the cost of calling `principal_value` on a `Quat` should be pretty minimal. Perhaps we should eliminate the branch, but it's not like we're calling `mod` or anything. It also shouldn't affect your application in #484, since (I assume) you're using `SPQuatFloating` joints instead of `QuaternionFloating` joints anyway. But let me know if you have any additional concerns.