### PR TITLE
Fix #434, array conversion consistency.

### DIFF
--- a/notebooks/Derivatives and gradients using ForwardDiff.ipynb
+++ b/notebooks/Derivatives and gradients using ForwardDiff.ipynb
@@ -15,6 +15,7 @@
    "source": [
     "using RigidBodyDynamics\n",
     "using ForwardDiff\n",
+    "using StaticArrays\n",
     "using Test\n",
     "using Random\n",
     "Random.seed!(1);"
@@ -130,8 +131,8 @@
     "    set_configuration!(state, q)\n",
     "    set_velocity!(state, v)\n",
     "    \n",
-    "    # return momentum converted to an `Array` (as this is the format that ForwardDiff expects)\n",
-    "    Array(momentum(state))\n",
+    "    # return momentum converted to an `SVector` (as ForwardDiff expects an `AbstractVector`)\n",
+    "    SVector(momentum(state))\n",
     "end"
    ]
   },
@@ -159,7 +160,7 @@
     }
    ],
    "source": [
-    "@test mom(v) == Array(momentum(float64state))"
+    "@test mom(v) == SVector(momentum(float64state))"
    ]
   },
   {
@@ -448,7 +449,7 @@
    "source": [
     "const out = zeros(6) # where we'll be storing our results\n",
     "mom!(out, v)\n",
-    "@test out == Array(momentum(float64state))"
+    "@test out == SVector(momentum(float64state))"
    ]
   },
   {

--- a/src/mechanism_state.jl
+++ b/src/mechanism_state.jl
@@ -482,10 +482,15 @@ $(SIGNATURES)
 
 Create a `Vector` that represents the same state as `state` (ordered `[q; v; s]`).
 """
-function Base.Vector(state::MechanismState{X}) where {X}
-    dest = Vector{X}(undef, num_positions(state) + num_velocities(state) + num_additional_states(state))
+function Base.Vector{T}(state::MechanismState) where T
+    dest = Vector{T}(undef, num_positions(state) + num_velocities(state) + num_additional_states(state))
     copyto!(dest, state)
 end
+
+Base.Vector(state::MechanismState{X}) where {X} = Vector{X}(state)
+Base.Array{T}(state::MechanismState) where {T} = Vector{T}(state)
+Base.Array(state::MechanismState{X}) where {X} = Array{X}(state)
+Base.convert(::Type{T}, state::MechanismState) where {T<:Array} = T(state)
 
 """
 $(SIGNATURES)

--- a/src/spatial/Spatial.jl
+++ b/src/spatial/Spatial.jl
@@ -56,5 +56,6 @@ include("threevectors.jl")
 include("spatialmotion.jl")
 include("spatialforce.jl")
 include("motion_force_interaction.jl")
+include("common.jl")
 
 end # module

--- a/src/spatial/common.jl
+++ b/src/spatial/common.jl
@@ -1,0 +1,46 @@
+for SpatialVector in (:Twist, :SpatialAcceleration, :Momentum, :Wrench)
+    @eval begin
+        # Basics
+        Base.eltype(::Type{$SpatialVector{T}}) where {T} = T
+        angular(v::$SpatialVector) = v.angular
+        linear(v::$SpatialVector) = v.linear
+
+        # Construct/convert given another spatial vector
+        $SpatialVector{T}(v::$SpatialVector{T}) where {T} = v
+        Base.convert(::Type{V}, v::$SpatialVector) where {V<:$SpatialVector} = V(v)
+
+        # Construct/convert to SVector
+        StaticArrays.SVector{6, T}(v::$SpatialVector) where {T} = convert(SVector{6, T}, [angular(v); linear(v)])
+        StaticArrays.SVector{6}(v::$SpatialVector{X}) where {X} = SVector{6, X}(v)
+        StaticArrays.SVector(v::$SpatialVector) = SVector{6}(v)
+        StaticArrays.SArray(v::$SpatialVector) = SVector(v)
+
+        # Construct/convert to Vector
+        Base.Vector{T}(v::$SpatialVector) where {T} = Vector(SVector{6, T}(v))
+        Base.Vector(v::$SpatialVector) = Vector(SVector{6}(v))
+        Base.Array{T}(v::$SpatialVector) where {T} = Vector(SVector{6, T}(v))
+        Base.Array(v::$SpatialVector) = Vector(SVector(v))
+    end
+end
+
+for SpatialMatrix in (:GeometricJacobian, :MomentumMatrix, :WrenchMatrix)
+    @eval begin
+        # Basics
+        Base.eltype(::Type{$SpatialMatrix{A}}) where {T, A<:AbstractMatrix{T}} = T
+        Base.size(m::$SpatialMatrix) = (6, size(angular(m), 2))
+        Base.size(m::$SpatialMatrix, d) = size(m)[d]
+        Base.transpose(m::$SpatialMatrix) = Transpose(m)
+        angular(m::$SpatialMatrix) = m.angular
+        linear(m::$SpatialMatrix) = m.linear
+
+        # Construct/convert given another spatial matrix
+        $SpatialMatrix(m::$SpatialMatrix{A}) where {A} = SpatialMatrix{A}(m)
+        Base.convert(::Type{$SpatialMatrix{A}}, m::$SpatialMatrix) where {A} = $SpatialMatrix{A}(m)
+        Base.convert(::Type{$SpatialMatrix{A}}, m::$SpatialMatrix{A}) where {A} = m
+
+        # Construct/convert to Matrix
+        (::Type{M})(m::$SpatialMatrix) where {M<:Matrix} = convert(M, [angular(m); linear(m)])
+        Base.Array(m::$SpatialMatrix) = Matrix(m)
+        Base.convert(::Type{M}, m::$SpatialMatrix) where {M<:Matrix} = M(m)
+    end
+end

--- a/src/spatial/common.jl
+++ b/src/spatial/common.jl
@@ -14,12 +14,12 @@ for SpatialVector in (:Twist, :SpatialAcceleration, :Momentum, :Wrench)
         StaticArrays.SVector{6}(v::$SpatialVector{X}) where {X} = SVector{6, X}(v)
         StaticArrays.SVector(v::$SpatialVector) = SVector{6}(v)
         StaticArrays.SArray(v::$SpatialVector) = SVector(v)
+        Base.convert(::Type{SA}, v::$SpatialVector) where {SA} = SA(v)
 
-        # Construct/convert to Vector
-        Base.Vector{T}(v::$SpatialVector) where {T} = Vector(SVector{6, T}(v))
-        Base.Vector(v::$SpatialVector) = Vector(SVector{6}(v))
-        Base.Array{T}(v::$SpatialVector) where {T} = Vector(SVector{6, T}(v))
-        Base.Array(v::$SpatialVector) = Vector(SVector(v))
+        function Base.Array(v::$SpatialVector)
+            Base.depwarn("Array(v) has been deprecated. Please use SVector(v) instead.", :Array)
+            SVector(v)
+        end
     end
 end
 
@@ -39,8 +39,7 @@ for SpatialMatrix in (:GeometricJacobian, :MomentumMatrix, :WrenchMatrix)
         Base.convert(::Type{$SpatialMatrix{A}}, m::$SpatialMatrix{A}) where {A} = m
 
         # Construct/convert to Matrix
-        (::Type{M})(m::$SpatialMatrix) where {M<:Matrix} = convert(M, [angular(m); linear(m)])
-        Base.Array(m::$SpatialMatrix) = Matrix(m)
-        Base.convert(::Type{M}, m::$SpatialMatrix) where {M<:Matrix} = M(m)
+        (::Type{A})(m::$SpatialMatrix) where {A<:Array} = convert(A, [angular(m); linear(m)])
+        Base.convert(::Type{A}, m::$SpatialMatrix) where {A<:Array} = A(m)
     end
 end

--- a/src/spatial/motion_force_interaction.jl
+++ b/src/spatial/motion_force_interaction.jl
@@ -25,12 +25,14 @@ struct SpatialInertia{T}
     moment::SMatrix{3, 3, T, 9}
     cross_part::SVector{3, T} # mass times center of mass
     mass::T
+
+    @inline function SpatialInertia{T}(frame::CartesianFrame3D, moment::AbstractMatrix, cross_part::AbstractVector, mass) where T
+        new{T}(frame, moment, cross_part, mass)
+    end
 end
 
-@inline function SpatialInertia(frame::CartesianFrame3D, moment::AbstractMatrix{T}, cross_part::AbstractVector{T}, mass::T) where T
-    @boundscheck size(moment) == (3, 3) || error("size mismatch")
-    @boundscheck size(cross_part) == (3,) || error("size mismatch")
-    new{T}(frame, moment, cross_part, mass)
+@inline function SpatialInertia(frame::CartesianFrame3D, moment::AbstractMatrix{T1}, cross_part::AbstractVector{T2}, mass::T3) where {T1, T2, T3}
+    SpatialInertia{promote_type(T1, T2, T3)}(frame, moment, cross_part, mass)
 end
 
 # SpatialInertia-specific functions

--- a/src/spatial/motion_force_interaction.jl
+++ b/src/spatial/motion_force_interaction.jl
@@ -25,12 +25,12 @@ struct SpatialInertia{T}
     moment::SMatrix{3, 3, T, 9}
     cross_part::SVector{3, T} # mass times center of mass
     mass::T
+end
 
-    @inline function SpatialInertia(frame::CartesianFrame3D, moment::AbstractMatrix{T}, cross_part::AbstractVector{T}, mass::T) where T
-        @boundscheck size(moment) == (3, 3) || error("size mismatch")
-        @boundscheck size(cross_part) == (3,) || error("size mismatch")
-        new{T}(frame, moment, cross_part, mass)
-    end
+@inline function SpatialInertia(frame::CartesianFrame3D, moment::AbstractMatrix{T}, cross_part::AbstractVector{T}, mass::T) where T
+    @boundscheck size(moment) == (3, 3) || error("size mismatch")
+    @boundscheck size(cross_part) == (3,) || error("size mismatch")
+    new{T}(frame, moment, cross_part, mass)
 end
 
 # SpatialInertia-specific functions

--- a/src/spatial/motion_force_interaction.jl
+++ b/src/spatial/motion_force_interaction.jl
@@ -50,11 +50,10 @@ end
 
 # Construct/convert to SMatrix
 function StaticArrays.SMatrix{6, 6, T, 36}(inertia::SpatialInertia) where {T}
-    # TODO: can probably improve performance if needed.
     J = SMatrix{3, 3, T}(inertia.moment)
     C = hat(SVector{3, T}(inertia.cross_part))
     m = T(inertia.mass)
-    [J  C; C' m * one(SMatrix{3, 3, T})]
+    [[J C]; [C' SMatrix{3, 3}(m * I)]]
 end
 StaticArrays.SMatrix{6, 6, T}(inertia::SpatialInertia) where {T} = SMatrix{6, 6, T, 36}(inertia)
 StaticArrays.SMatrix{6, 6}(inertia::SpatialInertia{T}) where {T} = SMatrix{6, 6, T}(inertia)
@@ -62,11 +61,17 @@ StaticArrays.SMatrix(inertia::SpatialInertia) = SMatrix{6, 6}(inertia)
 StaticArrays.SArray(inertia::SpatialInertia) = SMatrix(inertia)
 Base.convert(::Type{A}, inertia::SpatialInertia) where {A<:SArray} = A(inertia)
 
-# Construct/convert to Matrix
-Base.Matrix{T}(inertia::SpatialInertia) where {T} = Matrix(SMatrix{6, 6, T}(inertia))
-Base.Matrix(inertia::SpatialInertia) = Matrix(SMatrix{6, 6}(inertia))
-Base.Array{T}(inertia::SpatialInertia) where {T} = Matrix(SMatrix{6, 6, T}(inertia))
-Base.Array(inertia::SpatialInertia) = Matrix(SMatrix(inertia))
+function Base.convert(::Type{Matrix}, inertia::SpatialInertia) where {T<:Matrix}
+    Base.depwarn("This convert method is deprecated. Please use `$T(SMatrix(inertia))` instead or
+    reconsider whether conversion to Matrix is necessary.", :convert)
+    T(SMatrix(inertia))
+end
+
+function Base.Array(inertia::SpatialInertia)
+    Base.depwarn("This Array constructor is deprecated. Please use `Matrix(SMatrix(inertia))` instead or
+    reconsider whether conversion to Matrix is necessary.", :Array)
+    Matrix(SMatrix(inertia))
+end
 
 """
 $(SIGNATURES)

--- a/src/spatial/spatialforce.jl
+++ b/src/spatial/spatialforce.jl
@@ -70,6 +70,10 @@ struct Momentum{T}
     frame::CartesianFrame3D
     angular::SVector{3, T}
     linear::SVector{3, T}
+
+    @inline function Momentum{T}(frame::CartesianFrame3D, angular::AbstractVector, linear::AbstractVector) where T
+        new{T}(frame, angular, linear)
+    end
 end
 
 """
@@ -97,13 +101,17 @@ struct Wrench{T}
     frame::CartesianFrame3D
     angular::SVector{3, T}
     linear::SVector{3, T}
+
+    @inline function Wrench{T}(frame::CartesianFrame3D, angular::AbstractVector, linear::AbstractVector) where T
+        new{T}(frame, angular, linear)
+    end
 end
 
 for ForceSpaceElement in (:Momentum, :Wrench)
     @eval begin
-        function $ForceSpaceElement(frame::CartesianFrame3D, angular::AbstractVector{T1}, linear::AbstractVector{T2}) where {T1, T2}
-            T = promote_type(T1, T2)
-            $ForceSpaceElement{T}(frame, SVector{3, T}(angular), SVector{3, T}(linear))
+        # Construct with possibly eltype-heterogeneous inputs
+        @inline function $ForceSpaceElement(frame::CartesianFrame3D, angular::AbstractVector{T1}, linear::AbstractVector{T2}) where {T1, T2}
+            $ForceSpaceElement{promote_type(T1, T2)}(frame, angular, linear)
         end
 
         """

--- a/src/spatial/spatialmotion.jl
+++ b/src/spatial/spatialmotion.jl
@@ -20,22 +20,14 @@ struct GeometricJacobian{A<:AbstractMatrix}
 end
 
 # GeometricJacobian-specific functions
-Base.convert(::Type{GeometricJacobian{A}}, jac::GeometricJacobian{A}) where {A} = jac
-
-function Base.convert(::Type{GeometricJacobian{A}}, jac::GeometricJacobian) where {A}
+function GeometricJacobian{A}(jac::GeometricJacobian) where A
     GeometricJacobian(jac.body, jac.base, jac.frame, convert(A, angular(jac)), convert(A, linear(jac)))
 end
 
-Base.Array(jac::GeometricJacobian) = [Array(angular(jac)); Array(linear(jac))]
-Base.eltype(::Type{GeometricJacobian{A}}) where {A} = eltype(A)
+function GeometricJacobian{A}(jac::GeometricJacobian{A}) where A
+    GeometricJacobian(jac.body, jac.base, jac.frame, A(angular(jac)), A(linear(jac)))
+end
 
-Base.size(jac::GeometricJacobian) = (6, size(angular(jac), 2))
-Base.size(jac::GeometricJacobian, d) = size(jac)[d]
-
-Base.transpose(jac::GeometricJacobian) = Transpose(jac)
-
-angular(jac::GeometricJacobian) = jac.angular
-linear(jac::GeometricJacobian) = jac.linear
 change_base(jac::GeometricJacobian, base::CartesianFrame3D) = GeometricJacobian(jac.body, base, jac.frame, angular(jac), linear(jac))
 
 Base.:-(jac::GeometricJacobian) = GeometricJacobian(jac.base, jac.body, jac.frame, -angular(jac), -linear(jac))
@@ -65,10 +57,12 @@ end
 Base.@deprecate PointJacobian{M}(J::M, frame::CartesianFrame3D) where {M<:AbstractMatrix} PointJacobian(frame, J)
 Base.@deprecate PointJacobian(J::AbstractMatrix, frame::CartesianFrame3D) PointJacobian(frame, J)
 
-Base.Array(Jp::PointJacobian) = Matrix(Jp.J)
+# Construct/convert to Matrix
+(::Type{A})(jac::PointJacobian) where {A<:Array} = A(jac.J)
+Base.convert(::Type{A}, jac::PointJacobian) where {A<:Array} = A(jac)
 
-function point_velocity(Jp::PointJacobian, v::AbstractVector)
-    FreeVector3D(Jp.frame, Jp.J * v)
+function point_velocity(jac::PointJacobian, v::AbstractVector)
+    FreeVector3D(jac.frame, jac.J * v)
 end
 
 
@@ -132,16 +126,10 @@ for MotionSpaceElement in (:Twist, :SpatialAcceleration)
             $MotionSpaceElement(body, base, angular.frame, angular.v, linear.v)
         end
 
-        Base.convert(::Type{$MotionSpaceElement{T}}, m::$MotionSpaceElement{T}) where {T} = m
-        function Base.convert(::Type{$MotionSpaceElement{T}}, m::$MotionSpaceElement) where {T}
-            $MotionSpaceElement(m.body, m.base, m.frame, convert(SVector{3, T}, angular(m)), convert(SVector{3, T}, linear(m)))
+        # Construct/convert given another $MotionSpaceElement
+        function $MotionSpaceElement{T}(m::$MotionSpaceElement) where T
+            $MotionSpaceElement(m.body, m.base, m.frame, SVector{3, T}(angular(m)), SVector{3, T}(linear(m)))
         end
-        Base.convert(::Type{Vector{T}}, m::$MotionSpaceElement{T}) where {T} = [angular(m)...; linear(m)...]
-        Base.Array(m::$MotionSpaceElement{T}) where {T} = convert(Vector{T}, m)
-        Base.eltype(::Type{$MotionSpaceElement{T}}) where {T} = T
-
-        angular(m::$MotionSpaceElement) = m.angular
-        linear(m::$MotionSpaceElement) = m.linear
 
         function Base.show(io::IO, m::$MotionSpaceElement)
             print(io, "$($(string(MotionSpaceElement))) of \"$(string(m.body))\" w.r.t \"$(string(m.base))\" in \"$(string(m.frame))\":\nangular: $(angular(m)), linear: $(linear(m))")

--- a/test/test_mechanism_algorithms.jl
+++ b/test/test_mechanism_algorithms.jl
@@ -406,8 +406,8 @@ end
                 set_configuration!(x_autodiff, q_autodiff)
                 set_velocity!(x_autodiff, v_autodiff)
                 twist_autodiff = relative_twist(x_autodiff, body, base)
-                accel_vec = [ForwardDiff.partials(x, 1)::Float64 for x in (Array(twist_autodiff))]
-                @test isapprox(Array(Ṫ), accel_vec; atol = 1e-12)
+                accel_vec = [ForwardDiff.partials(x, 1)::Float64 for x in (SVector(twist_autodiff))]
+                @test isapprox(SVector(Ṫ), accel_vec; atol = 1e-12)
 
                 root = root_body(mechanism)
                 f = default_frame(body)
@@ -630,7 +630,7 @@ end
 
         # rate of change of momentum computed without autodiff:
         ḣ = Wrench(momentum_matrix(x), v̇) + momentum_rate_bias(x)
-        @test isapprox(ḣArray, Array(ḣ); atol = 1e-12)
+        @test isapprox(ḣArray, SVector(ḣ); atol = 1e-12)
     end
 
     @testset "inverse dynamics / external wrenches" begin

--- a/test/test_mechanism_algorithms.jl
+++ b/test/test_mechanism_algorithms.jl
@@ -100,6 +100,11 @@ end
         x3 = MechanismState(mechanism)
         copyto!(x3, Vector(x2))
         @test Vector(x3) == Vector(x2)
+
+        @test Vector{Float32}(x1) isa Vector{Float32}
+        @test Vector{Float32}(x1) ≈ Vector(x1) atol=1e-6
+        @test Array(x1) == Array{Float64}(x1) == convert(Array, x1) == convert(Array{Float64}, x1)
+        @test Vector(x1) == Vector{Float64}(x1) == convert(Vector, x1) == convert(Vector{Float64}, x1)
     end
 
     @testset "q̇ <-> v" begin

--- a/test/test_pd_control.jl
+++ b/test/test_pd_control.jl
@@ -48,7 +48,7 @@
             ω = T.angular
             ωddes = pd(gains, R, Rdes, ω, ωdes)
             v̇desjoint = v̇des[joint]
-            v̇desjoint .= Array([ωddes; zero(ωddes)])
+            v̇desjoint .= SVector([ωddes; zero(ωddes)])
             wrenches = control_dynamics_result.jointwrenches
             accelerations = control_dynamics_result.accelerations
             inverse_dynamics!(torques, wrenches, accelerations, state, v̇des)
@@ -91,7 +91,7 @@
             invx = inv(x)
             v = transform(twist_wrt_world(state, body), invx)
             v̇desjoint = v̇des[joint]
-            v̇desjoint .= Array(pd(transform(gains, invx), x, xdes, v, vdes))
+            v̇desjoint .= SVector(pd(transform(gains, invx), x, xdes, v, vdes))
             wrenches = control_dynamics_result.jointwrenches
             accelerations = control_dynamics_result.accelerations
             inverse_dynamics!(torques, wrenches, accelerations, state, v̇des)

--- a/test/test_spatial.jl
+++ b/test/test_spatial.jl
@@ -67,9 +67,9 @@ end
         I1 = transform(I2, H21)
         I3 = rand(SpatialInertia{Float64}, f2)
         @test I2.mass == I1.mass
-        @test isapprox(Array(I1), Ad(inv(H21))' * Array(I2) * Ad(inv(H21)); atol = 1e-12)
+        @test isapprox(SMatrix(I1), Ad(inv(H21))' * SMatrix(I2) * Ad(inv(H21)); atol = 1e-12)
         @test isapprox(I2, transform(I1, inv(H21)))
-        @test isapprox(Array(I2) + Array(I3), Array(I2 + I3); atol = 1e-12)
+        @test isapprox(SMatrix(I2) + SMatrix(I3), SMatrix(I2 + I3); atol = 1e-12)
         @inferred transform(zero(SpatialInertia{Float32}, f1), one(Transform3D, f1))
         @test I2 + zero(I2) == I2
 
@@ -90,7 +90,7 @@ end
         # @test isapprox(T2 + T1, T3) # used to be allowed, but makes code slower; just switch T1 and T2 around
         @test_throws ArgumentError T1 + rand(Twist{Float64}, f3, f2, f4) # wrong frame
         @test_throws ArgumentError T1 + rand(Twist{Float64}, f3, f4, f3) # wrong base
-        @test isapprox(Array(transform(T1, H31)), Ad(H31) * Array(T1))
+        @test isapprox(SVector(transform(T1, H31)), Ad(H31) * SVector(T1))
         @test T3 + zero(T3) == T3
 
         # 2.17 in Duindam:
@@ -110,7 +110,7 @@ end
         Random.seed!(66)
         W = rand(Wrench{Float64}, f2)
         H21 = rand(Transform3D, f2, f1)
-        @test isapprox(Array(transform(W, H21)), Ad(inv(H21))' * Array(W))
+        @test isapprox(SVector(transform(W, H21)), Ad(inv(H21))' * SVector(W))
         @test_throws ArgumentError transform(W, inv(H21)) # wrong frame
         @test W + zero(W) == W
 
@@ -144,10 +144,10 @@ end
         T2 = rand(Twist{Float64}, f2, f1, f1)
         H21 = rand(Transform3D, f2, f1)
         h = I * T
-        @test isapprox(Array(I) * Array(T), Array(h); atol = 1e-12)
+        @test isapprox(SMatrix(I) * SVector(T), SVector(h); atol = 1e-12)
         @test_throws ArgumentError I * T2 # wrong frame
         @test isapprox(transform(I, H21) * transform(T, H21), transform(h, H21))
-        @test isapprox(Array(transform(h, H21)), Ad(inv(H21))' * Array(h))
+        @test isapprox(SVector(transform(h, H21)), Ad(inv(H21))' * SVector(h))
         @test_throws ArgumentError transform(h, inv(H21)) # wrong frame
         @test h + zero(h) == h
     end
@@ -227,7 +227,7 @@ end
         T = rand(Twist{Float64}, f2, f1, f2)
         H = rand(Transform3D, f2, f1)
         Ek = kinetic_energy(I, T)
-        @test isapprox((1//2 * Array(T)' * Array(I) * Array(T))[1], Ek; atol = 1e-12)
+        @test isapprox((1//2 * SVector(T)' * SMatrix(I) * SVector(T))[1], Ek; atol = 1e-12)
         @test isapprox(kinetic_energy(transform(I, H), transform(T, H)), Ek; atol = 1e-12)
     end
 

--- a/test/test_spatial.jl
+++ b/test/test_spatial.jl
@@ -298,4 +298,48 @@ end
             @test rotation_angle(lin_error) ≈ 0 atol = 1e-8
         end
     end
+
+    @testset "Conversions to vector/matrix" begin
+        f = CartesianFrame3D()
+        angular = [1, 2, 3]
+        linear = [4, 5, 6]
+        twist = Twist(f, f, f, angular, linear)
+        svec = SVector(angular..., linear...)
+        twist64 = Twist(f, f, f, Float64.(angular), Float64.(linear))
+        svec64 = SVector{6, Float64}(svec)
+        @test twist isa Twist{Int}
+        @test Twist{Float64}(twist) === twist64
+        @test convert(Twist{Float64}, twist) === twist64
+        @test SVector{6, Float64}(twist) === svec64
+        @test convert(SVector{6, Float64}, twist) === svec64
+        @test SVector{6}(twist) === svec
+        @test convert(SVector{6}, twist) === svec
+        @test SArray(twist) === svec
+        @test convert(SArray, twist) === svec
+
+        moment = [1 2 3;
+                  2 4 5;
+                  3 5 6]
+        crosspart = [7, 8, 9]
+        mass = 10
+        inertia = SpatialInertia(f, moment, crosspart, mass)
+        inertia64 = SpatialInertia(f, Float64.(moment), Float64.(crosspart), Float64(mass))
+        mat = SMatrix(inertia) # already tested above
+        mat64 = SMatrix{6, 6, Float64}(mat)
+        @test inertia isa SpatialInertia{Int}
+        @test SpatialInertia{Float64}(inertia) === inertia64
+        @test convert(SpatialInertia{Float64}, inertia) === inertia64
+        @test SMatrix{6, 6}(inertia) === mat
+        @test convert(SMatrix{6, 6}, inertia) === mat
+        @test SMatrix{6, 6, Float64}(inertia) === mat64
+        @test convert(SMatrix{6, 6, Float64}, inertia) === mat64
+        @test SMatrix(inertia64) === mat64
+        @test convert(SMatrix, inertia64) === mat64
+
+        J = GeometricJacobian(f, f, f, rand(1:10, 3, 4), rand(1:10, 3, 4))
+        @test convert(Array, J) == Array(J) == Matrix(J) == [J.angular; J.linear]
+        @test convert(Array{Float64}, J) == Array{Float64}(J) == Matrix{Float64}(J) == Float64[J.angular; J.linear]
+        @test Matrix(J) == [J.angular; J.linear]
+        @test Matrix(J) == [J.angular; J.linear]
+    end
 end


### PR DESCRIPTION
Use SparseArrays as a model (see https://github.com/JuliaRobotics/RigidBodyDynamics.jl/issues/434#issuecomment-427955966).

Also reduce code duplication a bit. Needs tests.

CC:@rdeits; does this look OK?