### PR TITLE
More parse_urdf API updates

### DIFF
--- a/perf/runbenchmarks.jl
+++ b/perf/runbenchmarks.jl
@@ -9,7 +9,7 @@ const ScalarType = Float64
 function create_floating_atlas()
     url = "https://raw.githubusercontent.com/RobotLocomotion/drake/6e3ca768cbaabf15d0f2bed0fb5bd703fa022aa5/drake/examples/Atlas/urdf/atlas_minimal_contact.urdf"
     urdf = RigidBodyDynamics.cached_download(url, "atlas.urdf")
-    atlas = parse_urdf(urdf, scalar_type=ScalarType, root_joint_type=QuaternionFloating{ScalarType}())
+    atlas = parse_urdf(urdf, scalar_type=ScalarType, floating=true)
     atlas
 end
 

--- a/src/joint.jl
+++ b/src/joint.jl
@@ -6,7 +6,9 @@ $(TYPEDEF)
 The abstract supertype of all concrete joint types.
 """
 abstract type JointType{T} end
+
 Base.eltype(::Type{<:JointType{T}}) where {T} = T
+isfloating(::T) where {T<:JointType} = isfloating(T)
 num_velocities(::T) where {T<:JointType} = num_velocities(T)
 num_positions(::T) where {T<:JointType} = num_positions(T)
 num_constraints(::Type{T}) where {T<:JointType} = 6 - num_velocities(T)
@@ -452,7 +454,7 @@ $(SIGNATURES)
 Whether the joint is a floating joint, i.e., whether it imposes no constraints
 on the relative motions of its successor and predecessor bodies.
 """
-isfloating(joint::Joint) = isfloating(typeof(joint.joint_type))
+isfloating(joint::Joint) = isfloating(joint.joint_type)
 
 """
 $(SIGNATURES)

--- a/src/joint_types/quaternion_floating.jl
+++ b/src/joint_types/quaternion_floating.jl
@@ -77,7 +77,7 @@ end
 end
 
 @propagate_inbounds function joint_transform(jt::QuaternionFloating, frame_after::CartesianFrame3D, frame_before::CartesianFrame3D, q::AbstractVector)
-    Transform3D(frame_after, frame_before, rotation(jt, q), translation(jt, q))
+    Transform3D(frame_after, frame_before, rotation(jt, q, false), translation(jt, q))
 end
 
 @inline function motion_subspace(jt::QuaternionFloating{T}, frame_after::CartesianFrame3D, frame_before::CartesianFrame3D,

--- a/src/joint_types/revolute.jl
+++ b/src/joint_types/revolute.jl
@@ -11,17 +11,19 @@ struct Revolute{T} <: JointType{T}
     axis::SVector{3, T}
     rotation_from_z_aligned::RotMatrix3{T}
 
-    @doc """
-    $(SIGNATURES)
-
-    Construct a new `Revolute` joint type, allowing rotation about `axis`
-    (expressed in the frame before the joint).
-    """ ->
-    function Revolute(axis::AbstractVector{T}) where {T}
+    function Revolute{T}(axis::AbstractVector) where {T}
         a = normalize(axis)
         new{T}(a, rotation_between(SVector(zero(T), zero(T), one(T)), SVector{3, T}(a)))
     end
 end
+
+"""
+$(SIGNATURES)
+
+Construct a new `Revolute` joint type, allowing rotation about `axis`
+(expressed in the frame before the joint).
+"""
+Revolute(axis::AbstractVector{T}) where {T} = Revolute{T}(axis)
 
 Base.show(io::IO, jt::Revolute) = print(io, "Revolute joint with axis $(jt.axis)")
 

--- a/src/joint_types/sin_cos_revolute.jl
+++ b/src/joint_types/sin_cos_revolute.jl
@@ -12,17 +12,19 @@ struct SinCosRevolute{T} <: JointType{T}
     axis::SVector{3, T}
     rotation_from_z_aligned::RotMatrix3{T}
 
-    @doc """
-    $(SIGNATURES)
-
-    Construct a new `SinCosRevolute` joint type, allowing rotation about `axis`
-    (expressed in the frame before the joint).
-    """ ->
-    function SinCosRevolute(axis::AbstractVector{T}) where {T}
+    function SinCosRevolute{T}(axis::AbstractVector) where {T}
         a = normalize(axis)
         new{T}(a, rotation_between(SVector(zero(T), zero(T), one(T)), SVector{3, T}(a)))
     end
 end
+
+"""
+$(SIGNATURES)
+
+Construct a new `SinCosRevolute` joint type, allowing rotation about `axis`
+(expressed in the frame before the joint).
+"""
+SinCosRevolute(axis::AbstractVector{T}) where {T} = SinCosRevolute{T}(axis)
 
 Base.show(io::IO, jt::SinCosRevolute) = print(io, "SinCosRevolute joint with axis $(jt.axis)")
 

--- a/src/mechanism.jl
+++ b/src/mechanism.jl
@@ -1,3 +1,5 @@
+const DEFAULT_GRAVITATIONAL_ACCELERATION = SVector(0.0, 0.0, -9.81)
+
 """
 $(TYPEDEF)
 
@@ -17,12 +19,15 @@ mutable struct Mechanism{T}
 
     Create a new `Mechanism` containing only a root body, to which other bodies can
     be attached with joints.
+
+    The `gravity` keyword argument can be used to set the gravitational acceleration
+    (a 3-vector expressed in the `Mechanism`'s root frame). Default: `$(DEFAULT_GRAVITATIONAL_ACCELERATION)`.
     """ ->
-    function Mechanism(root_body::RigidBody{T}; gravity::SVector{3, T} = SVector(zero(T), zero(T), T(-9.81))) where {T}
+    function Mechanism(root_body::RigidBody{T}; gravity::AbstractVector=DEFAULT_GRAVITATIONAL_ACCELERATION) where {T}
         graph = DirectedGraph{RigidBody{T}, Joint{T}}()
         add_vertex!(graph, root_body)
         tree = SpanningTree(graph, root_body)
-        gravitational_acceleration = FreeVector3D(default_frame(root_body), gravity)
+        gravitational_acceleration = FreeVector3D(default_frame(root_body), convert(SVector{3, T}, gravity))
         environment = ContactEnvironment{T}()
         new{T}(graph, tree, environment, gravitational_acceleration, 0)
     end

--- a/src/urdf/URDF.jl
+++ b/src/urdf/URDF.jl
@@ -9,6 +9,7 @@ using RigidBodyDynamics.Graphs
 
 using RigidBodyDynamics: Bounds, upper, lower
 using RigidBodyDynamics: has_loops, canonicalize_graph!, joint_to_predecessor
+using RigidBodyDynamics: DEFAULT_GRAVITATIONAL_ACCELERATION
 using LinearAlgebra: ×
 
 export

--- a/src/urdf/parse.jl
+++ b/src/urdf/parse.jl
@@ -34,16 +34,17 @@ function parse_pose(::Type{T}, xml_pose::XMLElement) where {T}
     rot, trans
 end
 
-function parse_joint_type(::Type{T}, xml_joint::XMLElement) where {T}
+function parse_joint_type(::Type{T}, xml_joint::XMLElement,
+        floating_joint_type::Type{<:JointType{T}}, revolute_joint_type::Type{<:JointType{T}}) where {T}
     joint_type = attribute(xml_joint, "type")
     if joint_type == "revolute" || joint_type == "continuous" # TODO: handle joint limits for revolute
         axis = SVector{3}(parse_vector(T, find_element(xml_joint, "axis"), "xyz", "1 0 0"))
-        return Revolute(axis)
+        return revolute_joint_type(axis)
     elseif joint_type == "prismatic"
         axis = SVector{3}(parse_vector(T, find_element(xml_joint, "axis"), "xyz", "1 0 0"))
         return Prismatic(axis)
     elseif joint_type == "floating"
-        return QuaternionFloating{T}()
+        return floating_joint_type()
     elseif joint_type == "fixed"
         return Fixed{T}()
     elseif joint_type == "planar"
@@ -80,9 +81,9 @@ function parse_joint_bounds(jtype::JT, xml_joint::XMLElement) where {T, JT <: Jo
     position_bounds, velocity_bounds, effort_bounds
 end
 
-function parse_joint(::Type{T}, xml_joint::XMLElement) where {T}
+function parse_joint(::Type{T}, xml_joint::XMLElement, floating_joint_type, revolute_joint_type) where {T}
     name = attribute(xml_joint, "name")
-    joint_type = parse_joint_type(T, xml_joint)
+    joint_type = parse_joint_type(T, xml_joint, floating_joint_type, revolute_joint_type)
     position_bounds, velocity_bounds, effort_bounds = parse_joint_bounds(joint_type, xml_joint)
     return Joint(name, joint_type; position_bounds=position_bounds, velocity_bounds=velocity_bounds, effort_bounds=effort_bounds)
 end
@@ -112,12 +113,13 @@ function parse_root_link(mechanism::Mechanism{T}, xml_link::XMLElement, root_joi
     attach!(mechanism, parent, body, joint, joint_pose = joint_to_parent)
 end
 
-function parse_joint_and_link(mechanism::Mechanism{T}, xml_parent::XMLElement, xml_child::XMLElement, xml_joint::XMLElement) where {T}
+function parse_joint_and_link(mechanism::Mechanism{T}, xml_parent::XMLElement, xml_child::XMLElement, xml_joint::XMLElement,
+        floating_joint_type, revolute_joint_type) where {T}
     parentname = attribute(xml_parent, "name")
     candidate_parents = collect(filter(b -> string(b) == parentname, non_root_bodies(mechanism))) # skip root (name not parsed from URDF)
     length(candidate_parents) == 1 || error("Duplicate name: $(parentname)")
     parent = first(candidate_parents)
-    joint = parse_joint(T, xml_joint)
+    joint = parse_joint(T, xml_joint, floating_joint_type, revolute_joint_type)
     pose = parse_pose(T, find_element(xml_joint, "origin"))
     joint_to_parent = Transform3D(frame_before(joint), default_frame(parent), pose...)
     body = parse_body(T, xml_child, frame_after(joint))
@@ -132,13 +134,24 @@ Create a `Mechanism` by parsing a [URDF](https://wiki.ros.org/urdf/XML/model) fi
 Keyword arguments:
 
 * `scalar_type`: the scalar type used to store the `Mechanism`'s kinematic and inertial properties. Default: `Float64`.
-* `root_joint_type`: the joint type used to connect the parsed `Mechanism` to the world. Default: `Fixed{scalar_type}()`.
+* `floating`: whether to use a floating joint as the root joint. Default: false.
+* `floating_joint_type`: what `JointType` to use for floating joints. Default: `QuaternionFloating{scalar_type}`.
+* `revolute_joint_type`: what `JointType` to use for revolute joints. Default: `Revolute{scalar_type}`.
+* `root_joint_type`: the joint type used to connect the parsed `Mechanism` to the world. Default: `floating_joint_type()` if `floating`, `Fixed{scalar_type}()` otherwise.
 * `remove_fixed_tree_joints`: whether to remove any fixed joints present in the kinematic tree using [`remove_fixed_tree_joints!`](@ref). Default: `true`.
 """
 function parse_urdf(filename::AbstractString;
         scalar_type::Type{T}=Float64,
-        root_joint_type::JointType{T}=Fixed{scalar_type}(),
+        floating=false,
+        floating_joint_type::Type{<:JointType{T}}=QuaternionFloating{scalar_type},
+        revolute_joint_type::Type{<:JointType{T}}=Revolute{scalar_type},
+        root_joint_type::JointType{T}=floating ? floating_joint_type() : Fixed{scalar_type}(),
         remove_fixed_tree_joints=true) where T
+
+    if floating && !isfloating(root_joint_type)
+        error("Ambiguous input arguments: `floating` specified, but `root_joint_type` is not a floating joint type.")
+    end
+
     xdoc = parse_file(filename)
     xroot = LightXML.root(xdoc)
     @assert LightXML.name(xroot) == "robot"
@@ -169,7 +182,7 @@ function parse_urdf(filename::AbstractString;
     mechanism = Mechanism(rootbody)
     parse_root_link(mechanism, Graphs.root(tree).data, root_joint_type)
     for edge in edges(tree)
-        parse_joint_and_link(mechanism, source(edge, tree).data, target(edge, tree).data, edge.data)
+        parse_joint_and_link(mechanism, source(edge, tree).data, target(edge, tree).data, edge.data, floating_joint_type, revolute_joint_type)
     end
 
     if remove_fixed_tree_joints

--- a/src/urdf/parse.jl
+++ b/src/urdf/parse.jl
@@ -139,6 +139,7 @@ Keyword arguments:
 * `revolute_joint_type`: what `JointType` to use for revolute joints. Default: `Revolute{scalar_type}`.
 * `root_joint_type`: the joint type used to connect the parsed `Mechanism` to the world. Default: `floating_joint_type()` if `floating`, `Fixed{scalar_type}()` otherwise.
 * `remove_fixed_tree_joints`: whether to remove any fixed joints present in the kinematic tree using [`remove_fixed_tree_joints!`](@ref). Default: `true`.
+* `gravity`: gravitational acceleration as a 3-vector expressed in the `Mechanism`'s root frame. Default: `$(DEFAULT_GRAVITATIONAL_ACCELERATION)`.
 """
 function parse_urdf(filename::AbstractString;
         scalar_type::Type{T}=Float64,
@@ -146,7 +147,8 @@ function parse_urdf(filename::AbstractString;
         floating_joint_type::Type{<:JointType{T}}=QuaternionFloating{scalar_type},
         revolute_joint_type::Type{<:JointType{T}}=Revolute{scalar_type},
         root_joint_type::JointType{T}=floating ? floating_joint_type() : Fixed{scalar_type}(),
-        remove_fixed_tree_joints=true) where T
+        remove_fixed_tree_joints=true,
+        gravity::AbstractVector=DEFAULT_GRAVITATIONAL_ACCELERATION) where T
 
     if floating && !isfloating(root_joint_type)
         error("Ambiguous input arguments: `floating` specified, but `root_joint_type` is not a floating joint type.")
@@ -179,7 +181,7 @@ function parse_urdf(filename::AbstractString;
 
     # create mechanism from spanning tree
     rootbody = RigidBody{T}("world")
-    mechanism = Mechanism(rootbody)
+    mechanism = Mechanism(rootbody, gravity=gravity)
     parse_root_link(mechanism, Graphs.root(tree).data, root_joint_type)
     for edge in edges(tree)
         parse_joint_and_link(mechanism, source(edge, tree).data, target(edge, tree).data, edge.data, floating_joint_type, revolute_joint_type)

--- a/test/test_urdf.jl
+++ b/test/test_urdf.jl
@@ -157,9 +157,8 @@ end
             last(splitext(basename)) == ".urdf" || continue
             urdf = joinpath(urdfdir, basename)
             for floating in (true, false)
-                root_joint_type = floating ? QuaternionFloating{Float64}() : Fixed{Float64}()
                 for remove_fixed_joints_before in (true, false)
-                    mechanism = parse_urdf(urdf, remove_fixed_tree_joints=remove_fixed_joints_before, root_joint_type=root_joint_type)
+                    mechanism = parse_urdf(urdf, remove_fixed_tree_joints=remove_fixed_joints_before, floating=floating)
                     for remove_fixed_joints_after in (true, false)
                         test_urdf_serialize_deserialize(mechanism, remove_fixed_tree_joints=remove_fixed_joints_after)
                     end
@@ -176,7 +175,7 @@ end
             urdf = joinpath(urdfdir, basename)
 
             unmodified_mechanism = parse_urdf(urdf, remove_fixed_tree_joints=false)
-            floating_mechanism = parse_urdf(urdf, remove_fixed_tree_joints=false, root_joint_type=QuaternionFloating{Float64}())
+            floating_mechanism = parse_urdf(urdf, remove_fixed_tree_joints=false, floating=true)
 
             # Write unmodified mechanism to URDF using `include_root=false`, then parse
             # using the default `Fixed` joint type as the root joint type. Ensure we get


### PR DESCRIPTION
* add `floating` option (less verbose than using `root_joint_type=QuaternionFloating{Float64}()`.
* add `floating_joint_type` and `revolute_joint_type` to select between various ways of interpreting the `floating` and `continuous`/`revolute` URDF tags.
* fix #504, add parse_urdf keyword argument for setting gravitational acceleration.