### PR TITLE
Consistently omit normalization for quaternions.

### DIFF
--- a/src/joint_types/quaternion_floating.jl
+++ b/src/joint_types/quaternion_floating.jl
@@ -100,7 +100,7 @@ end
 end
 
 @propagate_inbounds function configuration_derivative_to_velocity!(v::AbstractVector, jt::QuaternionFloating, q::AbstractVector, q̇::AbstractVector)
-    quat = rotation(jt, q)
+    quat = rotation(jt, q, false)
     quatdot = SVector(q̇[1], q̇[2], q̇[3], q̇[4])
     ω = angular_velocity_in_body(quat, quatdot)
     posdot = translation(jt, q̇)
@@ -121,7 +121,7 @@ end
 end
 
 @propagate_inbounds function velocity_to_configuration_derivative!(q̇::AbstractVector, jt::QuaternionFloating, q::AbstractVector, v::AbstractVector)
-    quat = rotation(jt, q)
+    quat = rotation(jt, q, false)
     ω = angular_velocity(jt, v)
     linear = linear_velocity(jt, v)
     quatdot = quaternion_derivative(quat, ω)
@@ -132,7 +132,7 @@ end
 end
 
 @propagate_inbounds function velocity_to_configuration_derivative_jacobian(jt::QuaternionFloating, q::AbstractVector)
-    quat = rotation(jt, q)
+    quat = rotation(jt, q, false)
     vj = velocity_jacobian(quaternion_derivative, quat)
     R = RotMatrix(quat)
     # TODO: use hvcat once it's as fast
@@ -147,7 +147,7 @@ end
 end
 
 @propagate_inbounds function configuration_derivative_to_velocity_jacobian(jt::QuaternionFloating, q::AbstractVector)
-    quat = rotation(jt, q)
+    quat = rotation(jt, q, false)
     vj = velocity_jacobian(angular_velocity_in_body, quat)
     R_inv = RotMatrix(inv(quat))
     # TODO: use hvcat once it's as fast
@@ -251,7 +251,7 @@ end
 end
 
 @propagate_inbounds function principal_value!(q::AbstractVector, jt::QuaternionFloating)
-    quat = rotation(jt, q)
+    quat = rotation(jt, q, false)
     set_rotation!(q, jt, principal_value(quat))
     nothing
 end

--- a/src/joint_types/quaternion_spherical.jl
+++ b/src/joint_types/quaternion_spherical.jl
@@ -43,7 +43,7 @@ end
 end
 
 @propagate_inbounds function joint_transform(jt::QuaternionSpherical, frame_after::CartesianFrame3D, frame_before::CartesianFrame3D, q::AbstractVector)
-    quat = rotation(jt, q)
+    quat = rotation(jt, q, false)
     Transform3D(frame_after, frame_before, quat)
 end
 
@@ -69,7 +69,7 @@ end
 end
 
 @propagate_inbounds function configuration_derivative_to_velocity!(v::AbstractVector, jt::QuaternionSpherical, q::AbstractVector, q̇::AbstractVector)
-    quat = rotation(jt, q)
+    quat = rotation(jt, q, false)
     quatdot = SVector(q̇[1], q̇[2], q̇[3], q̇[4])
     v .= angular_velocity_in_body(quat, quatdot)
     nothing
@@ -83,18 +83,18 @@ end
 end
 
 @propagate_inbounds function velocity_to_configuration_derivative!(q̇::AbstractVector, jt::QuaternionSpherical, q::AbstractVector, v::AbstractVector)
-    quat = rotation(jt, q)
+    quat = rotation(jt, q, false)
     q̇ .= quaternion_derivative(quat, v)
     nothing
 end
 
 @propagate_inbounds function velocity_to_configuration_derivative_jacobian(jt::QuaternionSpherical, q::AbstractVector)
-    quat = rotation(jt, q)
+    quat = rotation(jt, q, false)
     velocity_jacobian(quaternion_derivative, quat)
 end
 
 @propagate_inbounds function configuration_derivative_to_velocity_jacobian(jt::QuaternionSpherical, q::AbstractVector)
-    quat = rotation(jt, q)
+    quat = rotation(jt, q, false)
     velocity_jacobian(angular_velocity_in_body, quat)
 end
 
@@ -134,7 +134,7 @@ end
 # uses exponential coordinates centered around q0
 @propagate_inbounds function local_coordinates!(ϕ::AbstractVector, ϕ̇::AbstractVector,
         jt::QuaternionSpherical, q0::AbstractVector, q::AbstractVector, v::AbstractVector)
-    quat = inv(rotation(jt, q0)) * rotation(jt, q)
+    quat = inv(rotation(jt, q0, false)) * rotation(jt, q, false)
     rv = RodriguesVec(quat)
     ϕstatic = SVector(rv.sx, rv.sy, rv.sz)
     ϕ .= ϕstatic
@@ -143,7 +143,7 @@ end
 end
 
 @propagate_inbounds function global_coordinates!(q::AbstractVector, jt::QuaternionSpherical, q0::AbstractVector, ϕ::AbstractVector)
-    quat0 = rotation(jt, q0)
+    quat0 = rotation(jt, q0, false)
     quat = quat0 * Quat(RodriguesVec(ϕ[1], ϕ[2], ϕ[3]))
     set_rotation!(q, jt, quat)
     nothing
@@ -156,7 +156,7 @@ end
 end
 
 @propagate_inbounds function principal_value!(q::AbstractVector, jt::QuaternionSpherical)
-    quat = rotation(jt, q)
+    quat = rotation(jt, q, false)
     set_rotation!(q, jt, principal_value(quat))
     nothing
 end


### PR DESCRIPTION
The main reason for this is to provide better support for scalar types for which square root or division are not defined.