### PR TITLE
Undo change to revolute joint `rand_configuration!` distribution.

### DIFF
--- a/src/joint_types/revolute.jl
+++ b/src/joint_types/revolute.jl
@@ -52,7 +52,7 @@ end
 end
 
 @propagate_inbounds function rand_configuration!(q::AbstractVector, ::Revolute)
-    q[1] = rand(-π : π)
+    q[1] = randn()
     nothing
  end
 


### PR DESCRIPTION
Probably too many things tacitly assume this distribution at this point.

Should revisit as part of #459, but we shouldn't introduce backwards
incompatible changes right now.

(Note: the change to `rand(-pi, pi)` caused a RigidBodySim test to fail).