### PR TITLE
Add more inline annotations.

### DIFF
--- a/src/joint.jl
+++ b/src/joint.jl
@@ -164,21 +164,21 @@ $(SIGNATURES)
 
 Return the length of the configuration vector of `joint`.
 """
-num_positions(joint::Joint) = num_positions(joint.joint_type)
+@inline num_positions(joint::Joint) = num_positions(joint.joint_type)
 
 """
 $(SIGNATURES)
 
 Return the length of the velocity vector of `joint`.
 """
-num_velocities(joint::Joint) = num_velocities(joint.joint_type)
+@inline num_velocities(joint::Joint) = num_velocities(joint.joint_type)
 
 """
 $(SIGNATURES)
 
 Return the number of constraints imposed on the relative twist between the joint's predecessor and successor
 """
-num_constraints(joint::Joint) = 6 - num_velocities(joint)
+@inline num_constraints(joint::Joint) = 6 - num_velocities(joint)
 
 """
 $(SIGNATURES)

--- a/src/spatial/motion_force_interaction.jl
+++ b/src/spatial/motion_force_interaction.jl
@@ -94,7 +94,7 @@ function Base.isapprox(x::SpatialInertia, y::SpatialInertia; atol = 1e-12)
     x.frame == y.frame && isapprox(x.moment, y.moment; atol = atol) && isapprox(x.cross_part, y.cross_part; atol = atol) && isapprox(x.mass, y.mass; atol = atol)
 end
 
-function Base.:+(inertia1::SpatialInertia, inertia2::SpatialInertia)
+@inline function Base.:+(inertia1::SpatialInertia, inertia2::SpatialInertia)
     @framecheck(inertia1.frame, inertia2.frame)
     SpatialInertia(inertia1.frame,
         inertia1.moment + inertia2.moment,
@@ -107,7 +107,7 @@ $(SIGNATURES)
 
 Transform the `SpatialInertia` to a different frame.
 """
-function transform(inertia::SpatialInertia, t::Transform3D)
+@inline function transform(inertia::SpatialInertia, t::Transform3D)
     @framecheck(t.from, inertia.frame)
     J = inertia.moment
     m = inertia.mass
@@ -171,13 +171,13 @@ for (ForceSpaceMatrix, ForceSpaceElement) in (:MomentumMatrix => :Momentum, :Mom
     end
 end
 
-function Base.:*(inertia::SpatialInertia, twist::Twist)
+@inline function Base.:*(inertia::SpatialInertia, twist::Twist)
     @framecheck(inertia.frame, twist.frame)
     ang, lin = mul_inertia(inertia.moment, inertia.cross_part, inertia.mass, angular(twist), linear(twist))
     Momentum(inertia.frame, ang, lin)
 end
 
-function Base.:*(inertia::SpatialInertia, jac::GeometricJacobian)
+@inline function Base.:*(inertia::SpatialInertia, jac::GeometricJacobian)
     @framecheck(inertia.frame, jac.frame)
     Jω = angular(jac)
     Jv = linear(jac)
@@ -198,7 +198,7 @@ to an inertial frame, achieve spatial acceleration ``\\dot{T}``.
 
 This wrench is also equal to the rate of change of momentum of the body.
 """
-function newton_euler(inertia::SpatialInertia, spatial_accel::SpatialAcceleration, twist::Twist)
+@inline function newton_euler(inertia::SpatialInertia, spatial_accel::SpatialAcceleration, twist::Twist)
     I = inertia
     T = twist
     Ṫ = spatial_accel
@@ -219,9 +219,9 @@ function newton_euler(inertia::SpatialInertia, spatial_accel::SpatialAcceleratio
     Wrench(frame, ang, lin)
 end
 
-torque!(τ::AbstractVector, jac::GeometricJacobian, wrench::Wrench) = mul!(τ, transpose(jac), wrench)
+@inline torque!(τ::AbstractVector, jac::GeometricJacobian, wrench::Wrench) = mul!(τ, transpose(jac), wrench)
 
-function torque(jac::GeometricJacobian, wrench::Wrench)
+@inline function torque(jac::GeometricJacobian, wrench::Wrench)
     τ = Vector{promote_type(eltype(jac), eltype(wrench))}(undef, size(jac, 2))
     torque!(τ, jac, wrench)
     τ
@@ -265,7 +265,7 @@ $(SIGNATURES)
 Compute the kinetic energy of a body with spatial inertia ``I``, which has
 twist ``T`` with respect to an inertial frame.
 """
-function kinetic_energy(inertia::SpatialInertia, twist::Twist)
+@inline function kinetic_energy(inertia::SpatialInertia, twist::Twist)
     @framecheck(inertia.frame, twist.frame)
     # TODO: should assert that twist.base is an inertial frame somehow
     ω = angular(twist)

--- a/src/spatial/spatialforce.jl
+++ b/src/spatial/spatialforce.jl
@@ -43,7 +43,7 @@ for ForceSpaceMatrix in (:MomentumMatrix, :WrenchMatrix)
             print(io, "$($(string(ForceSpaceMatrix))) expressed in \"$(string(m.frame))\":\n$(Array(m))")
         end
 
-        function transform(mat::$ForceSpaceMatrix, tf::Transform3D)
+        @inline function transform(mat::$ForceSpaceMatrix, tf::Transform3D)
             @framecheck(mat.frame, tf.from)
             R = rotation(tf)
             Av = R * linear(mat)
@@ -148,7 +148,7 @@ for ForceSpaceElement in (:Momentum, :Wrench)
 
         Transform the $($(string(ForceSpaceElement))) to a different frame.
         """
-        function transform(f::$ForceSpaceElement, tf::Transform3D)
+        @inline function transform(f::$ForceSpaceElement, tf::Transform3D)
             @framecheck(f.frame, tf.from)
             rot = rotation(tf)
             lin = rot * linear(f)
@@ -156,17 +156,17 @@ for ForceSpaceElement in (:Momentum, :Wrench)
             $ForceSpaceElement(tf.to, ang, lin)
         end
 
-        function Base.:+(f1::$ForceSpaceElement, f2::$ForceSpaceElement)
+        @inline function Base.:+(f1::$ForceSpaceElement, f2::$ForceSpaceElement)
             @framecheck(f1.frame, f2.frame)
             $ForceSpaceElement(f1.frame, angular(f1) + angular(f2), linear(f1) + linear(f2))
         end
 
-        function Base.:-(f1::$ForceSpaceElement, f2::$ForceSpaceElement)
+        @inline function Base.:-(f1::$ForceSpaceElement, f2::$ForceSpaceElement)
             @framecheck(f1.frame, f2.frame)
             $ForceSpaceElement(f1.frame, angular(f1) - angular(f2), linear(f1) - linear(f2))
         end
 
-        Base.:-(f::$ForceSpaceElement) = $ForceSpaceElement(f.frame, -angular(f), -linear(f))
+        @inline Base.:-(f::$ForceSpaceElement) = $ForceSpaceElement(f.frame, -angular(f), -linear(f))
 
         function Base.isapprox(x::$ForceSpaceElement, y::$ForceSpaceElement; atol = 1e-12)
             x.frame == y.frame && isapprox(angular(x), angular(y), atol = atol) && isapprox(linear(x), linear(y), atol = atol)

--- a/src/spatial/spatialmotion.jl
+++ b/src/spatial/spatialmotion.jl
@@ -51,7 +51,7 @@ $(SIGNATURES)
 
 Transform the `GeometricJacobian` to a different frame.
 """
-function transform(jac::GeometricJacobian, tf::Transform3D)
+@inline function transform(jac::GeometricJacobian, tf::Transform3D)
     @framecheck(jac.frame, tf.from)
     R = rotation(tf)
     ang = R * angular(jac)
@@ -201,7 +201,7 @@ $(SIGNATURES)
 
 Transform the `Twist` to a different frame.
 """
-function transform(twist::Twist, tf::Transform3D)
+@inline function transform(twist::Twist, tf::Transform3D)
     @framecheck(twist.frame, tf.from)
     ang, lin = transform_spatial_motion(angular(twist), linear(twist), rotation(tf), translation(tf))
     Twist(twist.body, twist.base, tf.to, ang, lin)
@@ -315,7 +315,7 @@ function Base.exp(twist::Twist)
     Transform3D(twist.body, twist.base, rot, trans)
 end
 
-function LinearAlgebra.cross(twist1::Twist, twist2::Twist)
+@inline function LinearAlgebra.cross(twist1::Twist, twist2::Twist)
     @framecheck(twist1.frame, twist2.frame)
     ang, lin = se3_commutator(angular(twist1), linear(twist1), angular(twist2), linear(twist2))
     SpatialAcceleration(twist2.body, twist2.base, twist2.frame, ang, lin)

--- a/src/spatial/util.jl
+++ b/src/spatial/util.jl
@@ -98,13 +98,13 @@ function rotation_vector_rate(rotation_vector::AbstractVector{T}, angular_veloci
 end
 
 
-function transform_spatial_motion(angular::SVector{3}, linear::SVector{3}, rot::R, trans::SVector{3}) where {R <: Rotation{3}}
+@inline function transform_spatial_motion(angular::SVector{3}, linear::SVector{3}, rot::R, trans::SVector{3}) where {R <: Rotation{3}}
     angular = rot * angular
     linear = rot * linear + trans × angular
     angular, linear
 end
 
-function mul_inertia(J, c, m, ω, v)
+@inline function mul_inertia(J, c, m, ω, v)
     angular = J * ω + c × v
     linear = m * v - c × ω
     angular, linear


### PR DESCRIPTION
Seems to help quite a bit. I guess Julia's cost model for inlining is a bit too conservative for this application.

`mass_matrix!`: 6.898 μs -> 5.862 μs
`dynamics_bias!`: 8.735 μs -> 6.347 μs