### PR TITLE
Stop using canonicalize_graph! in MechanismState ctor (and write_urdf).

### DIFF
--- a/src/graphs/spanning_tree.jl
+++ b/src/graphs/spanning_tree.jl
@@ -19,7 +19,7 @@ root(tree::SpanningTree) = tree.root
 edge_to_parent(vertex::V, tree::SpanningTree{V, E}) where {V, E} = tree.inedges[vertex_index(vertex)]
 edges_to_children(vertex::V, tree::SpanningTree{V, E}) where {V, E} = out_edges(vertex, tree)
 tree_index(edge, tree::SpanningTree{V, E}) where {V, E} = tree.edge_tree_indices[edge_index(edge)]
-tree_index(vertex::V, tree::SpanningTree{V, E}) where {V, E} = vertex == root(tree) ? 1 : tree_index(edge_to_parent(vertex, tree), tree) + 1
+tree_index(vertex::V, tree::SpanningTree{V, E}) where {V, E} = vertex === root(tree) ? 1 : tree_index(edge_to_parent(vertex, tree), tree) + 1
 
 function SpanningTree(g::DirectedGraph{V, E}, root::V, edges::AbstractVector{E}) where {V, E}
     n = num_vertices(g)
@@ -42,7 +42,7 @@ function SpanningTree(g::DirectedGraph{V, E}, root::V, edges::AbstractVector{E})
     SpanningTree(g, root, edges, inedges, outedges, edge_tree_indices)
 end
 
-function SpanningTree(g::DirectedGraph{V, E}, root::V, flipped_edge_map::AbstractDict = Dict{E, E}();
+function SpanningTree(g::DirectedGraph{V, E}, root::V, flipped_edge_map::Union{AbstractDict, Nothing} = nothing;
         next_edge = first #= breadth first =#) where {V, E}
     tree_edges = E[]
     tree_vertices = [root]
@@ -64,7 +64,9 @@ function SpanningTree(g::DirectedGraph{V, E}, root::V, flipped_edge_map::Abstrac
             rewire!(g, e, target(e, g), source(e, g))
             newedge = flip_direction(e)
             replace_edge!(g, e, newedge)
-            flipped_edge_map[e] = newedge
+            if flipped_edge_map !== nothing
+                flipped_edge_map[e] = newedge
+            end
             e = newedge
         end
 

--- a/src/mechanism_state.jl
+++ b/src/mechanism_state.jl
@@ -82,7 +82,6 @@ struct MechanismState{X, M, C, JointCollection}
         @assert length(s) == num_additional_states(m)
 
         # mechanism layout
-        canonicalize_graph!(m)
         nonrootbodies = collect(non_root_bodies(m))
         treejoints = JointCollection(tree_joints(m))
         nontreejoints = JointCollection(non_tree_joints(m))
@@ -93,8 +92,11 @@ struct MechanismState{X, M, C, JointCollection}
         nontreejointids = lasttreejointid + 1 : lastjointid
         predecessor_and_successor_ids = JointDict{Pair{BodyID, BodyID}}(
             JointID(j) => (BodyID(predecessor(j, m)) => BodyID(successor(j, m))) for j in joints(m))
-        ancestor_joint_mask = joint -> JointDict{Bool}(
-            JointID(j) => j ∈ path(m, successor(joint, m), root_body(m)) for j in tree_joints(m))
+        ancestor_joint_mask = function (joint)
+            JointDict{Bool}(
+                JointID(j) => j ∈ path(m, successor(joint, m), root_body(m)) for j in tree_joints(m)
+            )
+        end
         ancestor_joint_masks = JointDict{JointDict{Bool}}(JointID(j) => ancestor_joint_mask(j) for j in tree_joints(m))
         constraint_jacobian_structure = JointDict{TreePath{RigidBody{M}, Joint{M}}}(
             JointID(j) => path(m, predecessor(j, m), successor(j, m)) for j in joints(m))

--- a/src/urdf/URDF.jl
+++ b/src/urdf/URDF.jl
@@ -8,7 +8,7 @@ using DocStringExtensions
 using RigidBodyDynamics.Graphs
 
 using RigidBodyDynamics: Bounds, upper, lower
-using RigidBodyDynamics: has_loops, canonicalize_graph!, joint_to_predecessor
+using RigidBodyDynamics: has_loops, joint_to_predecessor
 using RigidBodyDynamics: DEFAULT_GRAVITATIONAL_ACCELERATION
 using LinearAlgebra: ×
 

--- a/src/urdf/write.jl
+++ b/src/urdf/write.jl
@@ -120,23 +120,19 @@ end
 
 function to_urdf(mechanism::Mechanism; robot_name::Union{Nothing, AbstractString}=nothing, include_root::Bool=true)
     @assert !has_loops(mechanism)
-
-    canonicalized = deepcopy(mechanism)
-    canonicalize_graph!(canonicalized)
-
     xdoc = XMLDocument()
     xroot = create_root(xdoc, "robot")
     if robot_name !== nothing
         set_attribute(xroot, "name", robot_name)
     end
-    bodies_to_include = include_root ? bodies(canonicalized) : non_root_bodies(canonicalized)
-    for body in bodies(canonicalized)
-        !include_root && isroot(body, canonicalized) && continue
+    bodies_to_include = include_root ? bodies(mechanism) : non_root_bodies(mechanism)
+    for body in bodies(mechanism)
+        !include_root && isroot(body, mechanism) && continue
         add_child(xroot, to_urdf(body))
     end
-    for joint in tree_joints(canonicalized)
-        !include_root && isroot(predecessor(joint, canonicalized), canonicalized) && continue
-        add_child(xroot, to_urdf(joint, canonicalized))
+    for joint in tree_joints(mechanism)
+        !include_root && isroot(predecessor(joint, mechanism), mechanism) && continue
+        add_child(xroot, to_urdf(joint, mechanism))
     end
     xdoc
 end


### PR DESCRIPTION
Using `canonicalize_graph!` in the `MechanismState` constructor was necessary
because removing a tree joint can make it so that the indices of the
tree joints are no longer ordered and contiguous. However, it made it so
that constructing `MechanismState`s was not thread-safe. In addition, it
was perhaps an unexpected (although harmless) behavior to have
the `Mechanism` be modified in any way upon `MechanismState` construction or
in `write_urdf`.

Instead, just canonicalize the graph in `remove_joint!` and `remove_fixed_tree_joints!`.

This is covered by the `reattach` test set.

Also some random minor changes in related code that I should have separate out, but OK.