### PR TITLE
Stop transforming wrenches back to body frame in inverse_dynamics.

### DIFF
--- a/src/spatial/spatialmotion.jl
+++ b/src/spatial/spatialmotion.jl
@@ -84,6 +84,12 @@ function LinearAlgebra.mul!(τ::AbstractVector, jac_transpose::Transpose{<:Any, 
     mul!(τ, transpose(jac.J), force.v)
 end
 
+function Base.:*(jac_transpose::Transpose{<:Any, <:PointJacobian}, force::FreeVector3D)
+    jac = parent(jac_transpose)
+    @framecheck jac.frame force.frame
+    transpose(jac.J) * force.v
+end
+
 """
 $(TYPEDEF)
 

--- a/test/test_mechanism_algorithms.jl
+++ b/test/test_mechanism_algorithms.jl
@@ -363,6 +363,7 @@ end
                 f = FreeVector3D(J_point.frame, rand(), rand(), rand())
                 mul!(τ, transpose(J_point), f)
                 @test τ == transpose(J_point.J) * f.v
+                @test τ == transpose(J_point) * f
             end
         end
 

--- a/test/test_spatial.jl
+++ b/test/test_spatial.jl
@@ -190,6 +190,7 @@ end
         k = fill(NaN, size(mat, 2))
         mul!(k, transpose(mat), vec)
         @test isapprox(k, angular(mat)' * angular(vec) + linear(mat)' * linear(vec), atol = 1e-14)
+        @test k == transpose(mat) * vec
     end
 
     @testset "momentum matrix" begin


### PR DESCRIPTION
Also add `transpose(jac) * wrench`, etc. for convenience (used in new `joint_wrenches_and_torques!` implementation).

A bit faster:

```julia
`dynamics_bias!`6.64 -> 6.36
`inverse_dynamics!` 5.87 -> 5.68
`dynamics!`: 18.92 -> 17.86
```

Will also allow removing `joint_torque!(τ::AbstractVector, joint::Joint, q::AbstractVector, joint_wrench::Wrench)`, thus simplifying the `Joint` interface and making it easier to create new `JointType`s.