### PR TITLE
Fix for FixedPointNumbers.Fixed.

### DIFF
--- a/src/spatial/motion_force_interaction.jl
+++ b/src/spatial/motion_force_interaction.jl
@@ -167,7 +167,7 @@ Transform the `SpatialInertia` to a different frame.
     Jnew = hat_squared(cnew)
     cnew += m * p
     Jnew -= hat_squared(cnew)
-    minv = ifelse(m > 0, inv(m), zero(m))
+    minv = m > 0 ? inv(m) : zero(m)
     Jnew *= minv
     Jnew += R * J * R'
     SpatialInertia(t.to, Jnew, cnew, convert(eltype(Jnew), m))


### PR DESCRIPTION
While `inv(zero(T))` is `NaN` for `T = Float64`, for
`T::FixedPointNumbers.Fixed` it results in an error. So replace the
`ifelse` by a normal `if` statement. Benchmark results are unchanged.