### PR TITLE
Improve mechanism modification API.

### DIFF
--- a/perf/runbenchmarks.jl
+++ b/perf/runbenchmarks.jl
@@ -104,7 +104,7 @@ function create_benchmark_suite()
         center_of_mass($state)
     end, setup = rand!($state), evals = 10)
 
-    mcmechanism, _ = maximal_coordinates(mechanism)
+    mcmechanism = maximal_coordinates(mechanism)
     mcstate = MechanismState{ScalarType}(mcmechanism)
     mcresult = DynamicsResult{ScalarType}(mcmechanism)
 

--- a/test/test_mechanism_algorithms.jl
+++ b/test/test_mechanism_algorithms.jl
@@ -39,7 +39,7 @@ end
     @testset "supports" begin
         Random.seed!(25)
         mechanism = randmech()
-        mc_mechanism, = maximal_coordinates(mechanism)
+        mc_mechanism = maximal_coordinates(mechanism)
         for m in [mechanism, mc_mechanism]
             state = MechanismState(m)
             for body in bodies(m)


### PR DESCRIPTION
Fix #318. Have all the mechanism modification functions return the modified or newly created mechanism, and nothing else. Keyword arguments, e.g. `bodymap` and `jointmap`, may be passed in to support the less frequent use case where these mappings are required.

Also remove the `newfloatingjoints` map from `maximal_coordinates!` as it can be trivially computed from the returned mechanism, and remove the `fixedjoints` output from `remove_fixed_tree_joints!` for the same reason.

This is a breaking change, so there should be a deprecation cycle before this is merged.