### PR TITLE
README: News -> Talks / publications, remove release announcements.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,24 +24,7 @@ Packages built on top of RigidBodyDynamics.jl include:
 * [StrandbeestRobot.jl](https://github.com/rdeits/StrandbeestRobot.jl) - simulations of a 12-legged parallel walking mechanism inspired by Theo Jansens's [Strandbeest](https://www.strandbeest.com/) using RigidBodyDynamics.jl.
 
 
-## News
+## Talks / publications
 
-* August 17, 2018: [tagged version 1.0.0](https://github.com/JuliaRobotics/RigidBodyDynamics.jl/releases/tag/v1.0.0). RigidBodyDynamics.jl will adhere to semantic versioning from this point on.
 * August 10, 2018: Robin Deits gave [a talk](https://www.youtube.com/watch?v=dmWQtI3DFFo) at JuliaCon 2018 demonstrating RigidBodyDynamics.jl and related packages.
-* August 4, 2018: [tagged version 0.9.0](https://github.com/JuliaRobotics/RigidBodyDynamics.jl/releases/tag/v0.9.0).
-* July 10, 2018: [tagged version 0.8.0](https://github.com/JuliaRobotics/RigidBodyDynamics.jl/releases/tag/v0.8.0). Drops support for Julia 0.6. Supports Julia 0.7 with no deprecation warnings (requires at least Julia 0.7.0-beta.105, *does not work on 0.7.0-beta*). Note that a few example notebooks don't work yet because of additional dependencies that haven't been updated for Julia 0.7. Also note the significant performance improvements (e.g., ~32% for `mass_matrix!`).
-* July 9, 2018: [tagged version 0.7.0](https://github.com/JuliaRobotics/RigidBodyDynamics.jl/releases/tag/v0.7.0). Supports Julia 0.7 (with some deprecation warnings). This is the last version to support Julia 0.6.
-* May 14, 2018: [tagged version 0.6.1](https://github.com/JuliaRobotics/RigidBodyDynamics.jl/releases/tag/v0.6.1).
-* April 26, 2018: [tagged version 0.6.0](https://github.com/JuliaRobotics/RigidBodyDynamics.jl/releases/tag/v0.6.0).
-* March 1, 2018: [tagged version 0.5.0](https://github.com/JuliaRobotics/RigidBodyDynamics.jl/releases/tag/v0.5.0).
-* September 20, 2017: [tagged version 0.4.0](https://github.com/JuliaRobotics/RigidBodyDynamics.jl/releases/tag/v0.4.0).
 * August 23, 2017: a video of a JuliaCon 2017 talk given by Robin Deits and Twan Koolen on using Julia for robotics [has been uploaded](https://www.youtube.com/watch?v=gPYc77M90Qg). It includes a brief demo of RigidBodyDynamics.jl and RigidBodyTreeInspector.jl. Note that RigidBodyDynamics.jl performance has significantly improved since this talk. The margins of the slides have unfortunately been cut off somewhat in the video.
-* August 22, 2017: [tagged version 0.3.0](https://github.com/JuliaRobotics/RigidBodyDynamics.jl/releases/tag/v0.3.0). Drops Julia 0.5 support.
-* June 18, 2017: [tagged version 0.2.0](https://github.com/JuliaLang/METADATA.jl/pull/9814). Supports Julia 0.6. This is the last version to support Julia 0.5.
-* March 20, 2017: [tagged version 0.1.0](https://github.com/JuliaLang/METADATA.jl/pull/8431).
-* February 16, 2017: [tagged version 0.0.6](https://github.com/JuliaLang/METADATA.jl/pull/7989).
-* February 14, 2017: [tagged version 0.0.5](https://github.com/JuliaLang/METADATA.jl/pull/7953).
-* December 12, 2016: [tagged version 0.0.4](https://github.com/JuliaLang/METADATA.jl/pull/7256).
-* December 6, 2016: [tagged version 0.0.3](https://github.com/JuliaLang/METADATA.jl/pull/7183).
-* October 28, 2016: [tagged version 0.0.2](https://github.com/JuliaLang/METADATA.jl/pull/6896).
-* October 24, 2016: [tagged version 0.0.1](https://github.com/JuliaLang/METADATA.jl/pull/6831).

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -17,4 +17,3 @@ Release checklist:
 * [ ] Update benchmark results, if relevant
 * [ ] Write release notes
 * [ ] Use Attobot to set up release
-* [ ] Update `NEWS.md`


### PR DESCRIPTION
Release announcements hadn't been kept up to date anyway and don't add that much value for the effort. If there are breaking changes in the future I might add an 'upgrade path' section.