### PR TITLE
Change multi-threading behavior of caches (AbstractTypeDicts).

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ julia:
 matrix:
   allow_failures:
   - julia: nightly
+env:
+  - JULIA_NUM_THREADS=2
 branches:
   only:
     - master

--- a/src/caches.jl
+++ b/src/caches.jl
@@ -4,7 +4,7 @@ function makevalue end
 
 function Base.getindex(c::C, ::Type{T}) where {C<:AbstractTypeDict, T}
     ReturnType = valuetype(C, T)
-    key = (objectid(T), Threads.threadid())
+    key = objectid(T)
     @inbounds for i in eachindex(c.keys)
         if c.keys[i] === key
             return c.values[i]::ReturnType
@@ -45,7 +45,7 @@ MechanismState{Float64, Float64, Float64, …}(…)
 """
 struct StateCache{M, JointCollection} <: AbstractTypeDict
     mechanism::Mechanism{M}
-    keys::Vector{Tuple{UInt64, Int}}
+    keys::Vector{UInt}
     values::Vector{MechanismState}
 end
 
@@ -73,7 +73,7 @@ Similar to [`StateCache`](@ref).
 """
 struct DynamicsResultCache{M} <: AbstractTypeDict
     mechanism::Mechanism{M}
-    keys::Vector{Tuple{UInt64, Int}}
+    keys::Vector{UInt}
     values::Vector{DynamicsResult{<:Any, M}}
 end
 
@@ -92,12 +92,12 @@ objects. Similar to [`StateCache`](@ref).
 struct SegmentedVectorCache{K, KeyRange<:AbstractUnitRange{K}} <: AbstractTypeDict
     ranges::IndexDict{K, KeyRange, UnitRange{Int}}
     length::Int
-    keys::Vector{Tuple{UInt64, Int}}
+    keys::Vector{UInt}
     values::Vector{SegmentedVector}
 end
 
 function SegmentedVectorCache(ranges::IndexDict{K, KeyRange, UnitRange{Int}}) where {K, KeyRange<:AbstractUnitRange{K}}
-    SegmentedVectorCache(ranges, sum(length, values(ranges)), Vector{Tuple{UInt64, Int}}(), Vector{SegmentedVector}())
+    SegmentedVectorCache(ranges, sum(length, values(ranges)), Vector{UInt}(), Vector{SegmentedVector}())
 end
 
 @inline function valuetype(::Type{SegmentedVectorCache{K, KeyRange}}, ::Type{T}) where {K, T, KeyRange}

--- a/test/test_caches.jl
+++ b/test/test_caches.jl
@@ -32,40 +32,69 @@ function cachetest(cache, eltypefun)
     @test @allocated(cache[Float64]) == 0
 end
 
-@testset "StateCache" begin
-    Random.seed!(1)
-    mechanism = randmech()
-    cache = StateCache(mechanism)
-    cachetest(cache, RigidBodyDynamics.state_vector_eltype)
-end
-
-@testset "DynamicsResultCache" begin
-    @testset "Basic mechanism" begin
-        Random.seed!(2)
+@testset "caches (nthreads = $(Threads.nthreads()))" begin
+    @testset "StateCache" begin
+        Random.seed!(1)
         mechanism = randmech()
-        cache = DynamicsResultCache(mechanism)
-        cachetest(cache, result -> eltype(result.v̇))
+        cache = StateCache(mechanism)
+        cachetest(cache, RigidBodyDynamics.state_vector_eltype)
     end
 
-    @testset "Mechanism with contact points (Issue #483)" begin
+    @testset "DynamicsResultCache" begin
+        @testset "Basic mechanism" begin
+            Random.seed!(2)
+            mechanism = randmech()
+            cache = DynamicsResultCache(mechanism)
+            cachetest(cache, result -> eltype(result.v̇))
+        end
+
+        @testset "Mechanism with contact points (Issue #483)" begin
+            Random.seed!(3)
+            mechanism = randmech()
+            contactmodel = SoftContactModel(hunt_crossley_hertz(k = 500e3),
+                ViscoelasticCoulombModel(0.8, 20e3, 100.))
+            body = rand(bodies(mechanism))
+            add_contact_point!(body,
+                ContactPoint(Point3D(default_frame(body), 0.0, 0.0, 0.0), contactmodel))
+            cache = DynamicsResultCache(mechanism)
+            cachetest(cache, result -> eltype(result.v̇))
+        end
+    end
+
+    @testset "SegmentedVectorCache" begin
         Random.seed!(3)
         mechanism = randmech()
-        contactmodel = SoftContactModel(hunt_crossley_hertz(k = 500e3),
-            ViscoelasticCoulombModel(0.8, 20e3, 100.))
-        body = rand(bodies(mechanism))
-        add_contact_point!(body,
-            ContactPoint(Point3D(default_frame(body), 0.0, 0.0, 0.0), contactmodel))
-        cache = DynamicsResultCache(mechanism)
-        cachetest(cache, result -> eltype(result.v̇))
+        state = MechanismState(mechanism)
+        cache = SegmentedVectorCache(RigidBodyDynamics.ranges(velocity(state)))
+        cachetest(cache, eltype)
     end
-end
 
-@testset "SegmentedVectorCache" begin
-    Random.seed!(3)
-    mechanism = randmech()
-    state = MechanismState(mechanism)
-    cache = SegmentedVectorCache(RigidBodyDynamics.ranges(velocity(state)))
-    cachetest(cache, eltype)
+    @testset "StateCache multi-threaded (#548)" begin
+        N = 2
+        mechanism = randmech()
+
+        state_caches = [StateCache(mechanism) for _ = 1 : N]
+        qs = let state = MechanismState(mechanism)
+            [(rand_configuration!(state); copy(configuration(state))) for _ = 1 : N]
+        end
+        vs = [rand(num_velocities(mechanism)) for _ = 1 : N]
+
+        Threads.@threads for i = 1 : N
+            state = state_caches[i][Float64]
+            set_configuration!(state, qs[i])
+            set_velocity!(state, vs[i])
+        end
+
+        for i = 1 : N
+            @test configuration(state_caches[i][Float64]) == qs[i]
+            @test velocity(state_caches[i][Float64]) == vs[i]
+        end
+
+        Threads.@threads for i = 1 : N
+            @test configuration(state_caches[i][Float64]) == qs[i]
+            @test velocity(state_caches[i][Float64]) == vs[i]
+        end
+    end
 end
 
 end # module


### PR DESCRIPTION
Fix #548.

This is a breaking change, although I doubt that a lot of people have
been relying on this behavior up to this point.

Previously, `AbstractTypeDict` subtypes such as `StateCache`,
`DynamicsResultCache`, and `SegmentedVectorCache` would use the thread
ID for the thread in which the value (e.g. `MechanismState`) was created as part
of the key. This was not needed for thread-safety (a misunderstanding on
my part), and led to some unexpected behavior (#548) as it wasn't
documented properly. I also now consider it to be a poor separation of
concerns: `AbstractTypeDict` should just be `Dict`-like, and `Dict`
doesn't do anything special in the presence of multiple threads.

See the following comments for more info on the past behavior and the
change:

* https://github.com/JuliaRobotics/RigidBodyDynamics.jl/issues/548#issuecomment-491300304
* https://github.com/JuliaRobotics/RigidBodyDynamics.jl/issues/548#issuecomment-491347036