### PR TITLE
`parse_urdf` API update

### DIFF
--- a/docs/src/urdf.md
+++ b/docs/src/urdf.md
@@ -1,6 +1,7 @@
 # URDF parsing and writing
 
 ```@docs
+default_urdf_joint_types
 parse_urdf
 write_urdf
 ```

--- a/src/urdf/URDF.jl
+++ b/src/urdf/URDF.jl
@@ -13,6 +13,7 @@ using RigidBodyDynamics: DEFAULT_GRAVITATIONAL_ACCELERATION
 using LinearAlgebra: ×
 
 export
+    default_urdf_joint_types,
     parse_urdf,
     write_urdf
 

--- a/test/test_double_pendulum.jl
+++ b/test/test_double_pendulum.jl
@@ -75,9 +75,9 @@
     @test isapprox(τ, M * v̇ + C * v + G, atol = 1e-12)
 
     # compare against URDF
-    for revolute_joint_type in [Revolute{Float64}, SinCosRevolute{Float64}]
+    for revolute_joint_type in [Revolute, SinCosRevolute]
         double_pendulum_urdf = parse_urdf(joinpath(@__DIR__, "urdf", "Acrobot.urdf"),
-            remove_fixed_tree_joints=false, revolute_joint_type=revolute_joint_type)
+            remove_fixed_tree_joints=false, joint_types=push!(default_urdf_joint_types(), "revolute" => revolute_joint_type))
         x_urdf = MechanismState(double_pendulum_urdf)
         for (i, j) in enumerate(joints(double_pendulum))
             urdf_joints = collect(joints(double_pendulum_urdf))


### PR DESCRIPTION
Allow the user to specify the mapping from URDF joint type name to
`JointType` subtype for all joint types (previously this was only
possible for revolute and floating joints). Do so using a single keyword
argument (`joint_types`), as opposed to a keyword argument for every joint type (`revolute_joint_type`, `floating_joint_type`, ...).