### PR TITLE
Fix for missing contact points after remove_fixed_tree_joints! call.

### DIFF
--- a/src/mechanism_modification.jl
+++ b/src/mechanism_modification.jl
@@ -242,6 +242,11 @@ function remove_fixed_tree_joints!(mechanism::Mechanism{T}) where T
             add_frame!(pred, tf)
         end
 
+        # Migrate contact points to parent body.
+        for point in contact_points(succ)
+            add_contact_point!(pred, point)
+        end
+
         # Add inertia to parent body.
         if has_defined_inertia(pred)
             inertia = spatial_inertia(succ)


### PR DESCRIPTION
* Add failing test case showing that `ContactPoints` can get lost when `remove_fixed_tree_joints!` is called.
* Fix by migrating contact points from parent to child.