### PR TITLE
Use promote_eltype instead of promote_type

### DIFF
--- a/src/RigidBodyDynamics.jl
+++ b/src/RigidBodyDynamics.jl
@@ -9,7 +9,7 @@ using DocStringExtensions
 using Reexport
 
 using Base.Iterators: filter, flatten
-using Base: @propagate_inbounds
+using Base: @propagate_inbounds, promote_eltype
 
 # mechanism-related types
 export

--- a/src/contact.jl
+++ b/src/contact.jl
@@ -227,7 +227,7 @@ end
 frame(halfspace::HalfSpace3D) = halfspace.point.frame
 
 function HalfSpace3D(point::Point3D, outward_normal::FreeVector3D)
-    T = promote_type(eltype(point), eltype(outward_normal))
+    T = promote_eltype(point, outward_normal)
     HalfSpace3D(convert(Point3D{SVector{3, T}}, point), convert(FreeVector3D{SVector{3, T}}, outward_normal))
 end
 

--- a/src/joint_types/fixed.jl
+++ b/src/joint_types/fixed.jl
@@ -15,32 +15,32 @@ num_velocities(::Type{<:Fixed}) = 0
 has_fixed_subspaces(jt::Fixed) = true
 isfloating(::Type{<:Fixed}) = false
 
-@inline function joint_transform(jt::Fixed{T}, frame_after::CartesianFrame3D, frame_before::CartesianFrame3D,
-        q::AbstractVector{X}) where {T, X}
-    S = promote_type(T, X)
+@inline function joint_transform(jt::Fixed, frame_after::CartesianFrame3D, frame_before::CartesianFrame3D,
+        q::AbstractVector)
+    S = promote_eltype(jt, q)
     one(Transform3D{S}, frame_after, frame_before)
 end
 
-@inline function joint_twist(jt::Fixed{T}, frame_after::CartesianFrame3D, frame_before::CartesianFrame3D,
-        q::AbstractVector{X}, v::AbstractVector{X}) where {T, X}
-    S = promote_type(T, X)
+@inline function joint_twist(jt::Fixed, frame_after::CartesianFrame3D, frame_before::CartesianFrame3D,
+        q::AbstractVector, v::AbstractVector)
+    S = promote_eltype(jt, q, v)
     zero(Twist{S}, frame_after, frame_before, frame_after)
 end
 
-@inline function joint_spatial_acceleration(jt::Fixed{T}, frame_after::CartesianFrame3D, frame_before::CartesianFrame3D,
-        q::AbstractVector{X}, v::AbstractVector{X}, vd::AbstractVector{XD}) where {T, X, XD}
-    S = promote_type(T, X, XD)
+@inline function joint_spatial_acceleration(jt::Fixed, frame_after::CartesianFrame3D, frame_before::CartesianFrame3D,
+        q::AbstractVector, v::AbstractVector, vd::AbstractVector)
+    S = promote_eltype(jt, q, v, vd)
     zero(SpatialAcceleration{S}, frame_after, frame_before, frame_after)
 end
 
-@inline function motion_subspace(jt::Fixed{T}, frame_after::CartesianFrame3D, frame_before::CartesianFrame3D,
-        q::AbstractVector{X}) where {T, X}
-    S = promote_type(T, X)
+@inline function motion_subspace(jt::Fixed, frame_after::CartesianFrame3D, frame_before::CartesianFrame3D,
+        q::AbstractVector)
+    S = promote_eltype(jt, q)
     GeometricJacobian(frame_after, frame_before, frame_after, zero(SMatrix{3, 0, S}), zero(SMatrix{3, 0, S}))
 end
 
-@inline function constraint_wrench_subspace(jt::Fixed{T}, joint_transform::Transform3D{X}) where {T, X}
-    S = promote_type(T, X)
+@inline function constraint_wrench_subspace(jt::Fixed, joint_transform::Transform3D)
+    S = promote_eltype(jt, joint_transform)
     angular = hcat(one(SMatrix{3, 3, S}), zero(SMatrix{3, 3, S}))
     linear = hcat(zero(SMatrix{3, 3, S}), one(SMatrix{3, 3, S}))
     WrenchMatrix(joint_transform.from, angular, linear)
@@ -49,9 +49,9 @@ end
 @inline zero_configuration!(q::AbstractVector, ::Fixed) = nothing
 @inline rand_configuration!(q::AbstractVector, ::Fixed) = nothing
 
-@inline function bias_acceleration(jt::Fixed{T}, frame_after::CartesianFrame3D, frame_before::CartesianFrame3D,
-        q::AbstractVector{X}, v::AbstractVector{X}) where {T, X}
-    S = promote_type(T, X)
+@inline function bias_acceleration(jt::Fixed, frame_after::CartesianFrame3D, frame_before::CartesianFrame3D,
+        q::AbstractVector, v::AbstractVector)
+    S = promote_eltype(jt, q, v)
     zero(SpatialAcceleration{S}, frame_after, frame_before, frame_after)
 end
 

--- a/src/joint_types/sin_cos_revolute.jl
+++ b/src/joint_types/sin_cos_revolute.jl
@@ -101,29 +101,29 @@ end
     Twist(frame_after, frame_before, frame_after, angular, zero(angular))
 end
 
-@inline function bias_acceleration(jt::SinCosRevolute{T}, frame_after::CartesianFrame3D, frame_before::CartesianFrame3D,
-        q::AbstractVector{X}, v::AbstractVector{X}) where {T, X}
-    S = promote_type(T, X)
+@inline function bias_acceleration(jt::SinCosRevolute, frame_after::CartesianFrame3D, frame_before::CartesianFrame3D,
+        q::AbstractVector, v::AbstractVector)
+    S = promote_eltype(jt, q, v)
     zero(SpatialAcceleration{S}, frame_after, frame_before, frame_after)
 end
 
-@propagate_inbounds function joint_spatial_acceleration(jt::SinCosRevolute{T}, frame_after::CartesianFrame3D, frame_before::CartesianFrame3D,
-        q::AbstractVector{X}, v::AbstractVector{X}, vd::AbstractVector{XD}) where {T, X, XD}
-    S = promote_type(T, X, XD)
+@propagate_inbounds function joint_spatial_acceleration(jt::SinCosRevolute, frame_after::CartesianFrame3D, frame_before::CartesianFrame3D,
+        q::AbstractVector, v::AbstractVector, vd::AbstractVector)
+    S = promote_eltype(jt, q, v, vd)
     angular = convert(SVector{3, S}, jt.axis * vd[1])
     SpatialAcceleration(frame_after, frame_before, frame_after, angular, zero(angular))
 end
 
-@inline function motion_subspace(jt::SinCosRevolute{T}, frame_after::CartesianFrame3D, frame_before::CartesianFrame3D,
-        q::AbstractVector{X}) where {T, X}
-    S = promote_type(T, X)
+@inline function motion_subspace(jt::SinCosRevolute, frame_after::CartesianFrame3D, frame_before::CartesianFrame3D,
+        q::AbstractVector)
+    S = promote_eltype(jt, q)
     angular = SMatrix{3, 1, S}(jt.axis)
     linear = zero(SMatrix{3, 1, S})
     GeometricJacobian(frame_after, frame_before, frame_after, angular, linear)
 end
 
-@inline function constraint_wrench_subspace(jt::SinCosRevolute{T}, joint_transform::Transform3D{X}) where {T, X}
-    S = promote_type(T, X)
+@inline function constraint_wrench_subspace(jt::SinCosRevolute, joint_transform::Transform3D)
+    S = promote_eltype(jt, joint_transform)
     R = convert(RotMatrix3{S}, jt.rotation_from_z_aligned)
     Rcols12 = R[:, SVector(1, 2)]
     angular = hcat(Rcols12, zero(SMatrix{3, 3, S}))

--- a/src/mechanism_state.jl
+++ b/src/mechanism_state.jl
@@ -964,7 +964,7 @@ function transform_to_root(state::MechanismState, frame::CartesianFrame3D, safe=
     tf
 end
 
-@propagate_inbounds function statesum(fun::F, state::MechanismState, itr, safe=true; init) where F
+@propagate_inbounds function statesum(fun::F, state::MechanismState, itr, init, safe=true) where F
     ret = init
     for x in itr
         ret += fun(state, x, safe)
@@ -976,27 +976,27 @@ end
     T = cache_eltype(state)
     update_twists_wrt_world!(state)
     update_spatial_inertias!(state)
-    statesum(momentum, state, body_itr, false, init=zero(Momentum{T}, root_frame(state.mechanism)))
+    statesum(momentum, state, body_itr, zero(Momentum{T}, root_frame(state.mechanism)), false)
 end
 
 @propagate_inbounds function momentum_rate_bias(state::MechanismState, body_itr)
     T = cache_eltype(state)
     update_bias_accelerations_wrt_world!(state)
     update_spatial_inertias!(state)
-    statesum(momentum_rate_bias, state, body_itr, false, init=zero(Wrench{T}, root_frame(state.mechanism)))
+    statesum(momentum_rate_bias, state, body_itr, zero(Wrench{T}, root_frame(state.mechanism)), false)
 end
 
 @propagate_inbounds function kinetic_energy(state::MechanismState, body_itr)
     T = cache_eltype(state)
     update_twists_wrt_world!(state)
     update_spatial_inertias!(state)
-    statesum(kinetic_energy, state, body_itr, false, init=zero(T))
+    statesum(kinetic_energy, state, body_itr, zero(T), false)
 end
 
 @propagate_inbounds function gravitational_potential_energy(state::MechanismState, body_itr)
     T = cache_eltype(state)
     update_transforms!(state)
-    statesum(gravitational_potential_energy, state, body_itr, false, init=zero(T))
+    statesum(gravitational_potential_energy, state, body_itr, zero(T), false)
 end
 
 for fun in (:momentum, :momentum_rate_bias, :kinetic_energy, :gravitational_potential_energy)

--- a/src/spatial/Spatial.jl
+++ b/src/spatial/Spatial.jl
@@ -49,6 +49,8 @@ using StaticArrays
 using Rotations
 using DocStringExtensions
 
+using Base: promote_eltype
+
 include("frame.jl")
 include("util.jl")
 include("transform3d.jl")

--- a/src/spatial/motion_force_interaction.jl
+++ b/src/spatial/motion_force_interaction.jl
@@ -48,8 +48,9 @@ Construct a `SpatialInertia` by specifying:
 
 For more convenient construction of `SpatialInertia`s, consider using the keyword argument constructor instead.
 """
-@inline function SpatialInertia(frame::CartesianFrame3D, moment::AbstractMatrix{T1}, cross_part::AbstractVector{T2}, mass::T3) where {T1, T2, T3}
-    SpatialInertia{promote_type(T1, T2, T3)}(frame, moment, cross_part, mass)
+@inline function SpatialInertia(frame::CartesianFrame3D, moment::AbstractMatrix, cross_part::AbstractVector, mass)
+    T = promote_eltype(moment, cross_part, mass)
+    SpatialInertia{T}(frame, moment, cross_part, mass)
 end
 
 """
@@ -263,7 +264,8 @@ end
 @inline torque!(τ::AbstractVector, jac::GeometricJacobian, wrench::Wrench) = mul!(τ, transpose(jac), wrench)
 
 @inline function torque(jac::GeometricJacobian, wrench::Wrench)
-    τ = Vector{promote_type(eltype(jac), eltype(wrench))}(undef, size(jac, 2))
+    T = promote_eltype(jac, wrench)
+    τ = Vector{T}(undef, size(jac, 2))
     torque!(τ, jac, wrench)
     τ
 end

--- a/src/spatial/spatialforce.jl
+++ b/src/spatial/spatialforce.jl
@@ -114,8 +114,9 @@ end
 for ForceSpaceElement in (:Momentum, :Wrench)
     @eval begin
         # Construct with possibly eltype-heterogeneous inputs
-        @inline function $ForceSpaceElement(frame::CartesianFrame3D, angular::AbstractVector{T1}, linear::AbstractVector{T2}) where {T1, T2}
-            $ForceSpaceElement{promote_type(T1, T2)}(frame, angular, linear)
+        @inline function $ForceSpaceElement(frame::CartesianFrame3D, angular::AbstractVector, linear::AbstractVector)
+            T = promote_eltype(angular, linear)
+            $ForceSpaceElement{T}(frame, angular, linear)
         end
 
         """

--- a/src/spatial/spatialmotion.jl
+++ b/src/spatial/spatialmotion.jl
@@ -157,8 +157,9 @@ for MotionSpaceElement in (:Twist, :SpatialAcceleration)
     @eval begin
         # Construct with possibly eltype-heterogeneous inputs
         @inline function $MotionSpaceElement(body::CartesianFrame3D, base::CartesianFrame3D, frame::CartesianFrame3D,
-                angular::AbstractVector{T1}, linear::AbstractVector{T2}) where {T1, T2}
-            $MotionSpaceElement{promote_type(T1, T2)}(body, base, frame, angular, linear)
+                angular::AbstractVector, linear::AbstractVector)
+            T = promote_eltype(angular, linear)
+            $MotionSpaceElement{T}(body, base, frame, angular, linear)
         end
 
         # Construct given FreeVector3Ds

--- a/src/spatial/transform3d.jl
+++ b/src/spatial/transform3d.jl
@@ -17,7 +17,7 @@ end
 Base.eltype(::Type{Transform3D{T}}) where {T} = T
 
 @inline function Transform3D(from::CartesianFrame3D, to::CartesianFrame3D, rot::Rotation{3}, trans::SVector{3})
-    T = promote_type(eltype(typeof(rot)), eltype(typeof(trans)))
+    T = promote_eltype(rot, trans)
     R = convert(RotMatrix3{T}, rot)
     @inbounds mat = @SMatrix [R[1] R[4] R[7] trans[1];
                               R[2] R[5] R[8] trans[2];

--- a/src/spatial/util.jl
+++ b/src/spatial/util.jl
@@ -25,7 +25,7 @@ colwise(f, A::AbstractMatrix, b::AbstractVector) = mapslices(x -> f(x, b), A, di
 end
 
 @inline function _colwise(f, ::Val{0}, a::StaticVector, B::StaticMatrix)
-    zero(similar_type(B, promote_type(eltype(a), eltype(B))))
+    zero(similar_type(B, promote_eltype(a, B)))
 end
 
 @inline function _colwise(f, M::Val, a::StaticVector, B::StaticMatrix)
@@ -41,7 +41,7 @@ end
 end
 
 @inline function _colwise(f, ::Val{0}, A::StaticMatrix, b::StaticVector)
-    zero(similar_type(A, promote_type(eltype(A), eltype(b))))
+    zero(similar_type(A, promote_eltype(A, b)))
 end
 
 @inline function _colwise(f, M::Val, A::StaticMatrix, b::StaticVector)


### PR DESCRIPTION
Don't assume that `eltype(::AbstractArray{T}) == T` (partial fix for #570), to support interaction with array types that lie about their element type.