### PR TITLE
Add base.view overloads for SegmentedVector.

### DIFF
--- a/src/custom_collections/SegmentedVector.jl
+++ b/src/custom_collections/SegmentedVector.jl
@@ -98,8 +98,10 @@ end
 
 Base.size(v::SegmentedVector) = size(v.parent)
 @propagate_inbounds Base.getindex(v::SegmentedVector, i::Int) = v.parent[i]
+@propagate_inbounds Base.getindex(v::SegmentedVector{K}, key::K) where {K} = v.segments[key] # TODO: deprecate in favor of view?
 @propagate_inbounds Base.setindex!(v::SegmentedVector, value, i::Int) = v.parent[i] = value
 Base.dataids(x::SegmentedVector) = Base.dataids(x.parent)
+@propagate_inbounds Base.view(v::SegmentedVector{K}, key::K) where {K} = v.segments[key]
 
 Base.parent(v::SegmentedVector) = v.parent
 segments(v::SegmentedVector) = v.segments

--- a/src/mechanism_state.jl
+++ b/src/mechanism_state.jl
@@ -11,8 +11,8 @@ const JointCacheDict{V} = CacheIndexDict{JointID, Base.OneTo{JointID}, V}
 
 
 ## SegmentedVector method overloads
-@propagate_inbounds Base.getindex(v::SegmentedVector{JointID}, id::JointID) = v.segments[id]
 @propagate_inbounds Base.getindex(v::SegmentedVector{JointID}, joint::Joint) = v[JointID(joint)]
+@propagate_inbounds Base.view(v::SegmentedVector{JointID}, joint::Joint) = Base.view(v, JointID(joint))
 function SegmentedVector(parent::AbstractVector{T}, joints::AbstractVector{<:Joint}, viewlengthfun) where T
     SegmentedVector{JointID, T, Base.OneTo{JointID}}(parent, joints, viewlengthfun)
 end

--- a/test/test_mechanism_algorithms.jl
+++ b/test/test_mechanism_algorithms.jl
@@ -118,6 +118,14 @@ end
                 @test RigidBodyDynamics.velocity_index_to_joint_id(x, i) == JointID(joint)
             end
         end
+
+        rand!(x)
+        q = configuration(x)
+        @test q != qcopy
+        for joint in tree_joints(mechanism)
+            q[joint] .= qcopy[joint]
+        end
+        @test q == qcopy
     end
 
     @testset "copyto! / Vector" begin


### PR DESCRIPTION
Allows stuff like `q[joint] .= 1`.