### PR TITLE
Bump minor version due to updated Julia version requirement

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "RigidBodyDynamics"
 uuid = "366cf18f-59d5-5db9-a4de-86a9f6786172"
-version = "2.2.1"
+version = "2.3.0"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"


### PR DESCRIPTION
The consensus from `#general` on Slack is that a new major version isn't required when increasing the minimum Julia version.