### PR TITLE
Update compat to include StaticArrays 1.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,10 +21,10 @@ LightXML = "0.8, 0.9"
 LoopThrottle = "0.1"
 Reexport = "0.2"
 Rotations = "1"
-StaticArrays = "^1.0.1"
+StaticArrays = "0.8, 0.9, 0.10, 0.11, 0.12, 1"
 TypeSortedCollections = "1"
 UnsafeArrays = "1"
-julia = "^1.0.0"
+julia = "1.3"
 
 [extras]
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"

--- a/Project.toml
+++ b/Project.toml
@@ -21,10 +21,10 @@ LightXML = "0.8, 0.9"
 LoopThrottle = "0.1"
 Reexport = "0.2"
 Rotations = "1"
-StaticArrays = "0.8, 0.9, 0.10, 0.11, 0.12"
+StaticArrays = "^1.0.1"
 TypeSortedCollections = "1"
 UnsafeArrays = "1"
-julia = "1.3"
+julia = "^1.0.0"
 
 [extras]
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"

--- a/test/test_spatial.jl
+++ b/test/test_spatial.jl
@@ -193,7 +193,6 @@ end
         @show size(mat)
         @show mat 
         @info "vec"
-        @show size(vec)
         @show vec
         mul!(k, transpose(mat), vec)
         @test isapprox(k, angular(mat)' * angular(vec) + linear(mat)' * linear(vec), atol = 1e-14)

--- a/test/test_spatial.jl
+++ b/test/test_spatial.jl
@@ -184,7 +184,7 @@ end
     end
 
     @testset "mul! with transpose(mat)" begin
-        Random.seed!(699)
+        Random.seed!(69)
         mat = WrenchMatrix(f1, rand(SMatrix{3, 4}), rand(SMatrix{3, 4}))
         vec = rand(SpatialAcceleration{Float64}, f2, f3, f1)
         k = fill(NaN, size(mat, 2))

--- a/test/test_spatial.jl
+++ b/test/test_spatial.jl
@@ -188,6 +188,14 @@ end
         mat = WrenchMatrix(f1, rand(SMatrix{3, 4}), rand(SMatrix{3, 4}))
         vec = rand(SpatialAcceleration{Float64}, f2, f3, f1)
         k = fill(NaN, size(mat, 2))
+        @info "mat"
+        @show typeof(mat)
+        @show size(mat)
+        @show mat 
+        @info "vec"
+        @show typeof(vec)
+        @show size(vec)
+        @show vec
         mul!(k, transpose(mat), vec)
         @test isapprox(k, angular(mat)' * angular(vec) + linear(mat)' * linear(vec), atol = 1e-14)
         @test k == transpose(mat) * vec

--- a/test/test_spatial.jl
+++ b/test/test_spatial.jl
@@ -184,7 +184,7 @@ end
     end
 
     @testset "mul! with transpose(mat)" begin
-        Random.seed!(69)
+        Random.seed!(699)
         mat = WrenchMatrix(f1, rand(SMatrix{3, 4}), rand(SMatrix{3, 4}))
         vec = rand(SpatialAcceleration{Float64}, f2, f3, f1)
         k = fill(NaN, size(mat, 2))
@@ -193,7 +193,6 @@ end
         @show size(mat)
         @show mat 
         @info "vec"
-        @show typeof(vec)
         @show size(vec)
         @show vec
         mul!(k, transpose(mat), vec)

--- a/test/test_spatial.jl
+++ b/test/test_spatial.jl
@@ -188,15 +188,9 @@ end
         mat = WrenchMatrix(f1, rand(SMatrix{3, 4}), rand(SMatrix{3, 4}))
         vec = rand(SpatialAcceleration{Float64}, f2, f3, f1)
         k = fill(NaN, size(mat, 2))
-        @info "mat"
-        @show typeof(mat)
-        @show size(mat)
-        @show mat 
-        @info "vec"
-        @show vec
         mul!(k, transpose(mat), vec)
         @test isapprox(k, angular(mat)' * angular(vec) + linear(mat)' * linear(vec), atol = 1e-14)
-        @test k == transpose(mat) * vec
+        @test isapprox(k, transpose(mat) * vec, atol = 1e-14)
     end
 
     @testset "momentum matrix" begin


### PR DESCRIPTION
Updated compat to include StaticArrays 1.0. This broke a spatial test due to floating-point errors. I replaced the `==` with a `isapprox(..,..,atol = 1e-14)` and the test passed. 