### PR TITLE
Removes unnecessary call to `setdirty!` in examples 1 and 3

### DIFF
--- a/examples/1. Quickstart - double pendulum/1. Quickstart - double pendulum.jl
+++ b/examples/1. Quickstart - double pendulum/1. Quickstart - double pendulum.jl
@@ -106,11 +106,6 @@ set_velocity!(state, shoulder, 1.)
 set_velocity!(state, elbow, 2.);
 
 
-# **Important**: a `MechanismState` contains cache variables that depend on the configurations and velocities of the joints. These need to be invalidated when the configurations and velocities are changed. To do this, call
-
-setdirty!(state)
-
-
 # The joint configurations and velocities are stored as `Vector`s (denoted $q$ and $v$ respectively in this package) inside the `MechanismState` object:
 
 q = configuration(state)

--- a/examples/3. Four-bar linkage/3. Four-bar linkage.jl
+++ b/examples/3. Four-bar linkage/3. Four-bar linkage.jl
@@ -134,9 +134,6 @@ set_velocity!(state, joint1, 0.5)
 set_velocity!(state, joint2, -0.47295)
 set_velocity!(state, joint3, 0.341)
 
-## Invalidate the cache variables
-setdirty!(state)
-
 # Next, we'll do a 3-second simulation:
 
 ts, qs, vs = simulate(state, 3., Δt = 1e-2);


### PR DESCRIPTION
Currently, somewhere in example 1 we can read:

https://github.com/JuliaRobotics/RigidBodyDynamics.jl/blob/6c40de7076d034c74e9d3a2cc66998b7c59f8b71/examples/1.%20Quickstart%20-%20double%20pendulum/1.%20Quickstart%20-%20double%20pendulum.jl#L101-L111

However, `set_configuration!` and `set_velocity!` already call `setdirty!` from within them:

https://github.com/JuliaRobotics/RigidBodyDynamics.jl/blob/6c40de7076d034c74e9d3a2cc66998b7c59f8b71/src/mechanism_state.jl#L397-L401

https://github.com/JuliaRobotics/RigidBodyDynamics.jl/blob/6c40de7076d034c74e9d3a2cc66998b7c59f8b71/src/mechanism_state.jl#L409-L413

Perhaps the call to `setdirty!` is in the examples because in some older version of RBD.jl `set_configuration!` and `set_velocity!` didn't invalidate the caches?