### PR TITLE
Fix broken allocation test on 1.5

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -27,6 +27,7 @@ UnsafeArrays = "1"
 julia = "1.3"
 
 [extras]
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 NBInclude = "0db19996-df87-5ea3-a455-e3a50d440464"
@@ -35,4 +36,4 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["ForwardDiff", "NBInclude", "LinearAlgebra", "Test", "Random", "Pkg"]
+test = ["BenchmarkTools", "ForwardDiff", "NBInclude", "LinearAlgebra", "Test", "Random", "Pkg"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,6 +14,7 @@ import ForwardDiff
 import LightXML
 
 using RigidBodyDynamics: ModifiedRodriguesParam
+using BenchmarkTools: @ballocated
 
 include("test_exports.jl")
 include("test_graph.jl")

--- a/test/test_mechanism_algorithms.jl
+++ b/test/test_mechanism_algorithms.jl
@@ -374,8 +374,7 @@ end
                     @test_throws ArgumentError point_jacobian!(J_point, x, p, transform(x, point, default_frame(base)))
                 end
                 point_jacobian!(J_point, x, p, point)
-                allocs = @allocated(point_jacobian!(J_point, x, p, point)) == 0
-                @test allocs == 0
+                @test(@ballocated(point_jacobian!($J_point, $x, $p, $point)) == 0)
                 J = geometric_jacobian(x, p)
                 T = Twist(J, velocity(x))
                 point_in_world = transform(x, point, root_frame(mechanism))

--- a/test/test_mechanism_algorithms.jl
+++ b/test/test_mechanism_algorithms.jl
@@ -374,14 +374,8 @@ end
                     @test_throws ArgumentError point_jacobian!(J_point, x, p, transform(x, point, default_frame(base)))
                 end
                 point_jacobian!(J_point, x, p, point)
-                let x = x
-                    if VERSION < v"1.5-"
-                        @test @allocated(point_jacobian!(J_point, x, p, point)) == 0
-                    else
-                        # https://github.com/JuliaRobotics/RigidBodyDynamics.jl/issues/590
-                        @test_broken @allocated(point_jacobian!(J_point, x, p, point)) == 0
-                    end
-                end
+                allocs = @allocated(point_jacobian!(J_point, x, p, point)) == 0
+                @test allocs == 0
                 J = geometric_jacobian(x, p)
                 T = Twist(J, velocity(x))
                 point_in_world = transform(x, point, root_frame(mechanism))


### PR DESCRIPTION
Wrapping the `@allocated` call in `@test` seems to be triggering an allocation; probably some compiler limit being triggered? Using `@ballocated` from BenchmarkTools (https://github.com/JuliaCI/BenchmarkTools.jl/pull/157),) seems like a more robust way to measure.

Ref https://github.com/JuliaLang/julia/issues/27270 and https://github.com/JuliaLang/julia/pull/33717. 