### PR TITLE
Revert from `generic_norm2` to `norm`

### DIFF
--- a/src/spatial/threevectors.jl
+++ b/src/spatial/threevectors.jl
@@ -75,7 +75,7 @@ LinearAlgebra.cross(v1::FreeVector3D, v2::FreeVector3D) = begin @framecheck(v1.f
 LinearAlgebra.dot(v1::FreeVector3D, v2::FreeVector3D) = begin @framecheck(v1.frame, v2.frame); v1.v ⋅ v2.v end
 Base.:*(t::Transform3D, vector::FreeVector3D) = begin @framecheck(t.from, vector.frame); FreeVector3D(t.to, rotation(t) * vector.v) end
 Base.:\(t::Transform3D, point::FreeVector3D) = begin @framecheck point.frame t.to; FreeVector3D(t.from, rotation(t) \ point.v) end
-LinearAlgebra.norm(v::FreeVector3D) = LinearAlgebra.generic_norm2(v.v)
+LinearAlgebra.norm(v::FreeVector3D) = norm(v.v)
 LinearAlgebra.normalize(v::FreeVector3D, p::Real = 2) = FreeVector3D(v.frame, normalize(v.v, p))
 
 # Mixed Point3D and FreeVector3D


### PR DESCRIPTION
This reverts commit 10de215a4017aeb3c967988fbdd5ef865b4937a1.

As shown below, `norm(a)` is as precise as `norm(Array(a))`.

```julia
julia> using BenchmarkTools, LinearAlgebra, StaticArrays

julia> a = SA[0, 1e-180]
2-element SVector{2, Float64} with indices SOneTo(2):
 0.0
 1.0e-180

julia> norm(a)
1.0e-180

julia> norm(Array(a))
1.0e-180

julia> a
2-element SVector{2, Float64} with indices SOneTo(2):
 0.0
 1.0e-180

julia> @btime norm($(Ref(a))[]) # standard norm of static array
  2.500 ns (0 allocations: 0 bytes)
1.0e-180

julia> @btime norm($(Ref(Vector(a)))[]) # standard norm of array
  6.792 ns (0 allocations: 0 bytes)
1.0e-180

julia> @btime LinearAlgebra.generic_norm2($(Ref((a)))[]) # generic_norm2 of static array
  3.334 ns (0 allocations: 0 bytes)
1.0e-180

julia> @btime LinearAlgebra.generic_norm2($(Ref(Vector(a)))[]) # generic_norm2 of array
  6.666 ns (0 allocations: 0 bytes)
1.0e-180
```

Related to https://github.com/JuliaRobotics/RigidBodyDynamics.jl/pull/622 and https://github.com/JuliaArrays/StaticArrays.jl/issues/913.